### PR TITLE
feat: add shipping tic setting

### DIFF
--- a/includes/abstracts/class-sst-abstract-cart.php
+++ b/includes/abstracts/class-sst-abstract-cart.php
@@ -234,7 +234,7 @@ abstract class SST_Abstract_Cart {
 			$cart_items[]     = new TaxCloud\CartItem(
 				count( $cart_items ),
 				SST_SHIPPING_ITEM,
-				apply_filters( 'wootax_shipping_tic', SST_DEFAULT_SHIPPING_TIC ),
+				sst_get_shipping_tic( $shipping_rate->method_id ),
 				apply_filters( 'wootax_shipping_price', $shipping_rate->cost, $shipping_rate ),
 				1
 			);

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -186,6 +186,38 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 			),
+			'shipping_tic'                => array(
+				'title'       => __( 'Shipping TIC', 'simple-sales-tax' ),
+				'type'        => 'select',
+				'options'     => array(
+					'11000' => __(
+						'11000 - Handling, crating, packing, preparation for mailing or delivery, and similar charges',
+						'simple-sales-tax'
+					),
+					'11010' => __(
+						'11010 - Transportation, shipping, postage, and similar charges',
+						'simple-sales-tax'
+					),
+					'11011' => __(
+						'11011 - Transportation, shipping, postage, and similar charges by USPS',
+						'simple-sales-tax'
+					),
+					'11012' => __(
+						'11012 - Transportation, shipping, postage, and similar charges with pick-up option',
+						'simple-sales-tax'
+					),
+					'11098' => __( '11098 - Colorado Retail Delivery Fees', 'simple-sales-tax' ),
+				),
+				'default'     => self::get_default_shipping_tic(),
+				'description' => __(
+					'Enter TIC code on <a href="https://taxcloud.net/tic" target="_blank">TaxCloud website</a> for details.',
+					'simple-sales-tax'
+				),
+				'desc_tip'    => __(
+					'Select the Taxability Information Code to apply to shipping charges.',
+					'simple-sales-tax'
+				),
+			),
 			'log_requests'                => array(
 				'title'       => __( 'Log Requests', 'simple-sales-tax' ),
 				'type'        => 'checkbox',
@@ -248,6 +280,26 @@ class SST_Settings {
 		);
 
 		return apply_filters( 'sst_settings_form_fields', $fields );
+	}
+
+	/**
+	 * Get the default value for the Shipping TIC option.
+	 *
+	 * @return string
+	 */
+	protected static function get_default_shipping_tic() {
+		$default_tic = SST_DEFAULT_SHIPPING_TIC;
+
+		if ( has_filter( 'wootax_shipping_tic' ) ) {
+			$default_tic = apply_filters_deprecated(
+				'wootax_shipping_tic',
+				array( $default_tic ),
+				'7.0.0',
+				'sst_shipping_tic'
+			);
+		}
+
+		return $default_tic;
 	}
 
 	/**

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -451,3 +451,15 @@ function sst_render_certificate_table( $user_id = 0, $options = array() ) {
 	sst_load_template( 'includes/views/html-add-certificate-modal.php' );
 	sst_load_template( 'includes/frontend/views/html-view-certificate.php' );
 }
+
+/**
+ * Gets the TIC to use for shipping charges.
+ *
+ * @param string $method_id Shipping method ID.
+ *
+ * @return string TIC to use for shipping charges.
+ */
+function sst_get_shipping_tic( $method_id ) {
+	$default_tic = SST_Settings::get( 'shipping_tic' );
+	return apply_filters( 'sst_shipping_tic', $default_tic, $method_id );
+}

--- a/includes/sst-update-functions.php
+++ b/includes/sst-update-functions.php
@@ -545,7 +545,7 @@ function sst_update_50_order_data() {
 						$new_package['contents'][] = new TaxCloud\CartItem(
 							count( $new_package['contents'] ),
 							isset( $identifiers[ SST_SHIPPING_ITEM ] ) ? $identifiers[ SST_SHIPPING_ITEM ] : $item_id,
-							apply_filters( 'wootax_shipping_tic', SST_DEFAULT_SHIPPING_TIC ),
+							sst_get_shipping_tic( $method_id ),
 							$total,
 							1
 						);


### PR DESCRIPTION
- Adds an dropdown to set the TIC for shipping charges through the UI under Advanced Settings > Shipping TIC.
- Deprecates the `wootax_shipping_tic` filter, which is now just used to change the default value for the Shipping TIC dropdown in cases where it exists.
- Introduces a new filter `sst_shipping_tic` to enable advanced usage where shipping TIC is set based on the shipping method used (e.g. 11000 can be used for flat rate and 11012 for USPS).