### PR TITLE
fix(wcfm): hide tax status dropdown in shipping method popup

### DIFF
--- a/includes/integrations/class-sst-wcfm.php
+++ b/includes/integrations/class-sst-wcfm.php
@@ -69,6 +69,7 @@ class SST_WCFM extends SST_Marketplace_Integration {
 
 		// Hide the default WCFM tax fields.
 		add_filter( 'wcfm_product_simple_fields_tax', '__return_empty_array' );
+		add_filter( 'show_shipping_zone_tax', '__return_false' );
 		add_action( 'wcfm_products_manage_tax_end', array( $this, 'output_tic_select' ) );
 		add_filter( 'wcfm_variation_edit_data', array( $this, 'add_tic_to_variation_edit_data' ), 10, 3 );
 		add_filter( 'wcfm_product_manage_fields_variations', array( $this, 'filter_variation_form_fields' ), 20, 2 );

--- a/includes/integrations/class-sst-wcfm.php
+++ b/includes/integrations/class-sst-wcfm.php
@@ -61,7 +61,7 @@ class SST_WCFM extends SST_Marketplace_Integration {
 			return;
 		}
 
-		// Print an error if the Dokan version is not supported.
+		// Print an error if the WCFM version is not supported.
 		if ( version_compare( WCFM_VERSION, $this->min_version, '<' ) ) {
 			add_action( 'admin_notices', array( $this, 'wcfm_version_notice' ) );
 			return;


### PR DESCRIPTION
Hides the unused/ignored "Tax Status" dropdown in the WCFM shipping method popup.

**Before**
![Screenshot 2022-07-28 at 10-24-52 Store Manager – Dokan Test Site](https://user-images.githubusercontent.com/5545098/181545711-0dbdf80b-1543-4a58-ac96-51c53994f42c.png)

**After**
![Screenshot 2022-07-28 at 10-24-11 Store Manager – Dokan Test Site](https://user-images.githubusercontent.com/5545098/181545777-635f5f54-81c1-4741-a93c-251d15531c09.png)
