### PR TITLE
fix: force exempt state input to appear as dropdown

### DIFF
--- a/includes/views/html-add-certificate-modal.php
+++ b/includes/views/html-add-certificate-modal.php
@@ -2,7 +2,7 @@
 /**
  * Add certificate modal template.
  *
- * @version 7.0.0
+ * @version 7.0.1
  */
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -39,6 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                             'ExemptState',
                             array(
                                 'type'     => 'state',
+                                'country'  => 'US',
                                 'label'    => esc_html__( 'Where does this exemption apply?', 'simple-sales-tax' ),
                                 'required' => true,
                                 'class'    => array( 'sst-input' ),


### PR DESCRIPTION
Forces the exempt state input to appear as a dropdown instead of a free form
text input by setting the `country` arg to `US`.

fixes #114