### PR TITLE
fix: potential fatal error in php 8 when certificate is added

### DIFF
--- a/assets/js/certificate-table.js
+++ b/assets/js/certificate-table.js
@@ -107,7 +107,7 @@
 			}
 
 			$.post( script_data.ajaxurl + '?action=sst_delete_certificate', requestData )
-				.done( function( response ) {
+				.then( function( response ) {
 					if ( ! response.success ) {
 						throw new Error( response.data );
 					}
@@ -192,7 +192,7 @@
 
 			// Add certificate via ajax call
 			$.post( script_data.ajaxurl + '?action=sst_add_certificate', requestData )
-				.done( function( response ) {
+				.then( function( response ) {
 					if ( ! response.success ) {
 						throw new Error( response.data );
 					}

--- a/assets/js/meta-box.js
+++ b/assets/js/meta-box.js
@@ -212,7 +212,7 @@ jQuery(function($) {
 			};
 
 			jQuery.post(postUrl, data)
-				.done(function(response) {
+				.then(function(response) {
 					if (!response.success) {
 						throw new Error(response.data);
 					}

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -186,36 +186,50 @@ class SST_Ajax {
 		);
 
 		// Construct certificate.
-		$exempt_state = new TaxCloud\ExemptState(
-			$form_data['ExemptState'],
-			$form_data['PurchaserExemptionReason'],
-			$form_data['IDNumber']
-		);
+		try {
+			$exempt_state = new TaxCloud\ExemptState(
+				$form_data['ExemptState'],
+				$form_data['PurchaserExemptionReason'],
+				$form_data['IDNumber']
+			);
 
-		$tax_id = new TaxCloud\TaxID(
-			$form_data['TaxType'],
-			$form_data['IDNumber'],
-			$form_data['StateOfIssue']
-		);
+			$tax_id = new TaxCloud\TaxID(
+				$form_data['TaxType'],
+				$form_data['IDNumber'],
+				$form_data['StateOfIssue']
+			);
 
-		$certificate = new TaxCloud\ExemptionCertificate(
-			array( $exempt_state ),
-			false,
-			'',
-			$form_data['first_name'],
-			$form_data['last_name'],
-			'',
-			$form_data['address_1'],
-			$form_data['address_2'],
-			$form_data['city'],
-			$form_data['state'],
-			$form_data['postcode'],
-			$tax_id,
-			$form_data['PurchaserBusinessType'],
-			$form_data['PurchaserBusinessTypeOtherValue'],
-			$form_data['PurchaserExemptionReason'],
-			$form_data['PurchaserExemptionReasonValue']
-		);
+			$certificate = new TaxCloud\ExemptionCertificate(
+				array( $exempt_state ),
+				false,
+				'',
+				$form_data['first_name'],
+				$form_data['last_name'],
+				'',
+				$form_data['address_1'],
+				$form_data['address_2'],
+				$form_data['city'],
+				$form_data['state'],
+				$form_data['postcode'],
+				$tax_id,
+				$form_data['PurchaserBusinessType'],
+				$form_data['PurchaserBusinessTypeOtherValue'],
+				$form_data['PurchaserExemptionReason'],
+				$form_data['PurchaserExemptionReasonValue']
+			);
+		} catch ( Error $ex ) {
+			SST_Logger::add(
+				sprintf(
+					__(
+						'Failed to add exemption certificate. Error was: %1$s',
+						'simple-sales-tax'
+					),
+					$ex->getMessage()
+				)
+			);
+
+			wp_send_json_error( __( 'Invalid request.', 'simple-sales-tax' ), 400 );
+		}
 
 		// Add certificate.
 		if ( isset( $_POST['user_id'] ) ) {

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -220,6 +220,7 @@ class SST_Ajax {
 		} catch ( Throwable $ex ) {
 			SST_Logger::add(
 				sprintf(
+					/* translators: 1 - error message */
 					__(
 						'Failed to add exemption certificate. Error was: %1$s',
 						'simple-sales-tax'

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -217,7 +217,7 @@ class SST_Ajax {
 				$form_data['PurchaserExemptionReason'],
 				$form_data['PurchaserExemptionReasonValue']
 			);
-		} catch ( Error $ex ) {
+		} catch ( Throwable $ex ) {
 			SST_Logger::add(
 				sprintf(
 					__(


### PR DESCRIPTION
In PHP 8 environments a fatal error will occur if an invalid value is submitted
for certain form fields like ExemptState where only specified constant values
are allowed. This adds some error handling to catch any such errors and send
back an "Invalid request" error to the client.

Ideally we'd have more comprehensive validation but this will get us by for now.

fixes #115