### PR TITLE
fix: increase z-index for cert modal dropdowns

### DIFF
--- a/assets/css/certificate-modal.css
+++ b/assets/css/certificate-modal.css
@@ -107,5 +107,5 @@ span.table-action-sep {
 }
 
 .sst-select2-dropdown {
-    z-index: 10000;
+    z-index: 100002;
 }


### PR DESCRIPTION
Fixes a recent regression causing the add certificate modal dropdowns to appear behind the modal.