### PR TITLE
Fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ For more information, please check our [plugin page](https://wordpress.org/plugi
 
 ## Support
 
-If you find a bug in our plugin, [open a new issue](https://github.com/bporcelli/simplesalestax/issues/new) right here in GitHub. For other issues please [contact us](https://taxcloud.com/contact-us/).
+If you find a bug in our plugin, [open a new issue](https://github.com/FedTax/simplesalestax/issues/new) right here in GitHub. For other issues please [contact us](https://taxcloud.com/contact-us/).
 
 ## Contributing
 
-* [Submit an issue](https://github.com/bporcelli/simplesalestax/issues/new) or work on a feature branch and [submit a pull request](https://github.com/bporcelli/simplesalestax/compare).
+* [Submit an issue](https://github.com/FedTax/simplesalestax/issues/new) or work on a feature branch and [submit a pull request](https://github.com/FedTax/simplesalestax/compare).
 * Follow [WordPress Coding Standards](http://codex.wordpress.org/WordPress_Coding_Standards)

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ If you find a bug in our plugin, [open a new issue](https://github.com/FedTax/si
 ## Contributing
 
 * [Submit an issue](https://github.com/FedTax/simplesalestax/issues/new) or work on a feature branch and [submit a pull request](https://github.com/FedTax/simplesalestax/compare).
-* Follow [WordPress Coding Standards](http://codex.wordpress.org/WordPress_Coding_Standards)
+* Follow [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/)

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ Currently we only support the use case where the marketplace acts as the seller 
 
 == Changelog ==
 
-See [Releases](https://github.com/bporcelli/simplesalestax/releases).
+See [Releases](https://github.com/FedTax/simplesalestax/releases).
 
 == Upgrade Notice ==
 
@@ -139,6 +139,6 @@ None yet.
 
 == Translation ==
 
-If you would like to translate Simple Sales Tax into your language, please [submit a pull request](https://github.com/bporcelli/simplesalestax/pulls) with your .po file added to the "languages" directory or email your completed translation to bporcelli@taxcloud.com.
+If you would like to translate Simple Sales Tax into your language, please [submit a pull request](https://github.com/FedTax/simplesalestax/pulls) with your .po file added to the "languages" directory or email your completed translation to bporcelli@taxcloud.com.
 
 Thanks in advance for your contribution!


### PR DESCRIPTION
* Fix the links to GitHub. Previously they went to `bporcelli/simplesalestax` and GitHub redirected them to `FedTax/simplesalestax`.
* Fix the link to the WordPress Coding Standards. Previously they went to a page that tells the user they've been moved.