### PR TITLE
Respect the tax-exempt status from another plugin

### DIFF
--- a/includes/frontend/class-sst-checkout.php
+++ b/includes/frontend/class-sst-checkout.php
@@ -72,6 +72,14 @@ class SST_Checkout extends SST_Abstract_Cart {
 	 * @since 5.0
 	 */
 	public function calculate_tax_totals( $total, $cart ) {
+		// The Tax Exemption for WooCommerce (PRO) plugin sets the
+		// is_tax_exempt session variable, and we need to respect that so we
+		// can allow customers that aren't logged in to show no tax when
+		// they're tax-exempt.
+		if ( WC()->session->get( 'is_tax_exempt', false ) ) {
+			return $total;
+		}
+
 		$tax_total = 0;
 
 		$this->cart = new SST_Cart_Proxy( $cart );


### PR DESCRIPTION
[DEV-3877](https://taxcloud.atlassian.net/browse/DEV-3877) has a customer complaining that tax exempt customers during checkout while not logged in are being charged tax.

To test:
1. Purchase and install "Tax Exemption for WooCommerce (PRO)" plugin from [RelyWP's website](https://relywp.com/plugins/tax-exemption-woocommerce/). You may need to update the checkout page to the WordPress short code `[woocommerce_checkout]` to see the checkbox:
   ![Screenshot 2025-03-01 173303](https://github.com/user-attachments/assets/6d3a3d07-fcf6-4199-b172-04f39d17822c)
1. Add something taxable to your cart and go to the checkout page without logging in. Enter an address so the tax field populates:
   ![Screenshot 2025-03-01 173411](https://github.com/user-attachments/assets/b9b9da8d-40c9-43b4-8f74-6a84f8f3b2e5)
1. Click the "I want to claim tax exemption" checkbox. The tax field should be set to zero:
   ![Screenshot 2025-03-01 173451](https://github.com/user-attachments/assets/14bc1cb3-45c8-4803-b2ec-97abd3ce7aa3)
1. Uncheck the exemption checkbox and the tax field should go back to charging tax.

[DEV-3877]: https://taxcloud.atlassian.net/browse/DEV-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ