### PR TITLE
Remove sanitize_text_field call that breaks everything

### DIFF
--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -229,9 +229,8 @@ class SST_Ajax {
 		}
 
 		// Parse jQuery serialized items.
-		$raw_items = sanitize_text_field( wp_unslash( $_POST['items'] ) );
+		$raw_items = wp_unslash( $_POST['items'] );
 		parse_str( $raw_items, $items );
-
 		$items = wc_clean( $items );
 
 		// Save items and recalc taxes.


### PR DESCRIPTION
The `wc_save_order_items()` method expects something like:
```json
{
  "order_taxes": {
    "33": "4"
  },
  "order_item_id": [
    "28",
    "29"
  ],
  "order_item_tax_class": {
    "28": "",
    "29": ""
  },
  "order_item_qty": {
    "28": "1",
    "29": "1"
  },
  "refund_order_item_qty": {
    "28": "",
    "29": ""
  },
  "line_subtotal": {
    "28": "19.99",
    "29": "9.99"
  },
  "line_total": {
    "28": "19.99",
    "29": "9.99"
  },
  "refund_line_total": {
    "28": "",
    "29": ""
  },
  "line_subtotal_tax": {
    "28": {
      "4": "0"
    },
    "29": {
      "4": "0"
    }
  },
  "line_tax": {
    "28": {
      "4": "0"
    },
    "29": {
      "4": "0"
    }
  },
  "refund_line_tax": {
    "28": {
      "4": ""
    },
    "29": {
      "4": ""
    }
  }
}
```
where each named field has the corresponding values for the two line items.

What we were sending Woo before looked like:
```json
{
  "order_taxes33": "4",
  "order_item_id": "29",
  "order_item_tax_class28": "",
  "order_item_qty28": "1",
  "refund_order_item_qty28": "",
  "line_subtotal28": "19.99",
  "line_total28": "19.99",
  "refund_line_total28": "",
  "line_subtotal_tax284": "0",
  "line_tax284": "0",
  "refund_line_tax284": "",
  "order_item_tax_class29": "",
  "order_item_qty29": "1",
  "refund_order_item_qty29": "",
  "line_subtotal29": "9.99",
  "line_total29": "9.99",
  "refund_line_total29": "",
  "line_subtotal_tax294": "0",
  "line_tax294": "0",
  "refund_line_tax294": ""
}
```
which is not very useful.