### PR TITLE
Release 8.3.0 – Woo Marketplace Compliance & Plugin Rebrand

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,17 @@
 Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- [8.3.0] - 2025-07-11 =
+
+Changed:
+- Renamed plugin from **Simple Sales Tax** to **TaxCloud for WooCommerce**.
+- Updated plugin assets and branding for the WordPress.org plugin page.
+- Applied changes required for compliance with **WooCommerce Marketplace** QIT validation.
+
+Fixed:
+- Resolved issues causing failures in **WooCommerce onboarding task list** and **Payments settings navigation** during QIT automated tests.
+- Adjusted hook timing and database logic to avoid interfering with setup flows.
+
 - [8.2.4] - 2025-04-24 =
 
 Changed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	public $version = '8.2.4';
+	public $version = '8.3.0';
 
 	/**
 	 * The singleton plugin instance.

--- a/includes/integrations/class-sst-dokan.php
+++ b/includes/integrations/class-sst-dokan.php
@@ -98,10 +98,8 @@ class SST_Dokan extends SST_Marketplace_Integration {
 		<div class="notice notice-error">
 			<p>
 				<?php
-				printf(
-					esc_html__( 'TaxCloud for WooCommerce does not support the installed version of Dokan. Dokan %s+ is required.', 'simple-sales-tax' ),
-					esc_html( $this->min_version )
-				);
+				// translators: %s is the minimum required version of Dokan.
+				printf(esc_html__( 'TaxCloud for WooCommerce does not support the installed version of Dokan. Dokan %s+ is required.', 'simple-sales-tax' ),esc_html( $this->min_version ));
 				?>
 			</p>
 		</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplesalestax",
-  "version": "8.2.4",
+  "version": "8.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simplesalestax",
-      "version": "8.2.4",
+      "version": "8.3.0",
       "license": "GPL-3.0+",
       "dependencies": {
         "npm": "^10.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.2.4",
+  "version": "8.3.0",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -11,19 +11,19 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Simplify sales tax calculations, reporting, and filing by connecting your WooCommerce store to TaxCloud.
 
 == Description ==
-# Simplify Sales Tax Compliance with TaxCloud for WooCommerce (formerly Simple Sales Tax)
-TaxCloud is the right-sized sales tax solution for growing eCommerce brands on WooCommerce. We take the complexity out of sales tax, automating calculation, nexus tracking, and filing across all 50 states and more than 13,000 tax jurisdictions.
+## Simplify Sales Tax Compliance with TaxCloud for WooCommerce (formerly Simple Sales Tax)
+[TaxCloud](http://www.taxcloud.com) is the right-sized sales tax solution for growing eCommerce brands on WooCommerce. We take the complexity out of sales tax, automating calculation, nexus tracking, and filing across all 50 states and more than 13,000 tax jurisdictions.
 
 ## Quick, Code-Free Setup
-Getting started takes just a few clicks. TaxCloud’s native WooCommerce plugin integrates in minutes. No custom development required. Simply assign product tax codes and connect your store to begin calculating sales tax accurately and in real time.
+Getting started takes just a few clicks. TaxCloud’s native WooCommerce plugin integrates in minutes. No custom development required. Simply assign [product tax codes](https://taxcloud.com/sales-tax-tic-codes/) and connect your store to begin calculating sales tax accurately and in real time.
 ## Automated, Accurate Sales Tax at Checkout
-Avoid manual errors with real-time sales tax calculations across all jurisdictions. TaxCloud ensures every transaction includes the correct rate, whether you’re selling in one state or across the country.
+Avoid manual errors with real-time [sales tax calculations](https://taxcloud.com/calculate-collect-sales-tax/) across all jurisdictions. TaxCloud ensures every transaction includes the correct rate, whether you’re selling in one state or across the country.
 ## Streamlined Filing and Remittance
-We make filing as simple as collecting. You can upload your Orders Report manually or opt into automatic syncing. We’ll register, file and remit your returns in each state. Benefit from filing savings through the Streamlined Sales Tax (SST) program where eligible.
+We make filing as simple as collecting. You can upload your Orders Report manually or opt into automatic syncing. We’ll register, file and remit your returns in each state. Benefit from filing savings through the [Streamlined Sales Tax (SST)](https://taxcloud.com/streamlined-sales-tax-csp-provider/) program where eligible.
 ## Nexus Monitoring and Audit-Ready Reporting
-We track your sales against each state’s economic nexus thresholds and alert you when you’re approaching compliance obligations. When you reach nexus, you’ll have the documentation, reports, and filing support you need to stay compliant and audit-ready.
+We track your sales against each state’s [economic nexus thresholds](https://taxcloud.com/economic-nexus-tracking/) and alert you when you’re approaching compliance obligations. When you reach nexus, you’ll have the documentation, reports, and filing support you need to stay compliant and audit-ready.
 ## Affordable, Transparent Pricing
-Our pricing is built for growing businesses. No hidden fees. Eligible merchants can save on filing in SST states. Switching from other providers? We’ll help you migrate and import historical orders with ease.
+[Our pricing is built for growing businesses](https://taxcloud.com/taxcloud-pricing/). No hidden fees. Eligible merchants can save on filing in SST states. Switching from other providers? We’ll help you migrate and import historical orders with ease.
 ## Reliable U.S.-Based Support
 Get expert support every step of the way. Our dedicated, U.S.-based team will set your account up right from day one and provide ongoing assistance whenever you need it.
 Why Businesses Choose TaxCloud for WooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: taxcloud
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5
 Tested up to: 6.8
-Stable tag: 8.2.4
+Stable tag: 8.3.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === TaxCloud for WooCommerce ===
 Contributors: taxcloud
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
-Requires at least: 4.5
+Requires at least: 4.5.0
 Tested up to: 6.8
 Stable tag: 8.3.0
 Requires PHP: 7.4

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.2.4
+ * Version:              8.3.0
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later


### PR DESCRIPTION

### 📝 Description

This PR introduces version **8.3.0** of the plugin with the following key updates:

#### ✅ Changed
- Renamed the plugin from **Simple Sales Tax** to **TaxCloud for WooCommerce** to align with branding and official naming.
- Updated plugin assets (headers, icons, banners) for the WordPress.org plugin page.
- Refactored internal naming and references for consistency with the new brand.
- Adjusted plugin behavior and logic to comply with **Woo Marketplace** standards, based on feedback from **Woo QIT**.

#### 🛠 Fixed
- Resolved E2E test failures related to:
  - "Can hide the task list"
  - "Payments task list item links to Payments settings page"
- Moved logic that modifies tax rates to run only after WooCommerce is fully initialized.
- Avoided early execution of translation loading to remove warnings during plugin checks.

---

✅ This release completes all required fixes for Woo Marketplace submission.  
