### PR TITLE
Release 8.3.1 – Fix deployment and metadata issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- [8.3.1] - 2025-07-11 =
+
+Fixed:
+- Re-deployed version 8.3.0 to ensure all files and assets were correctly included in the WordPress.org release.
+- Resolved issues with missing or outdated plugin metadata in the initial 8.3.0 deployment.
+
 - [8.3.0] - 2025-07-11 =
 
 Changed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	public $version = '8.3.0';
+	public $version = '8.3.1';
 
 	/**
 	 * The singleton plugin instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplesalestax",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simplesalestax",
-      "version": "8.3.0",
+      "version": "8.3.1",
       "license": "GPL-3.0+",
       "dependencies": {
         "npm": "^10.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.8
-Stable tag: 8.3.0
+Stable tag: 8.3.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.3.0
+ * Version:              8.3.1
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later


### PR DESCRIPTION
### Changelog

**Version 8.3.1** – 2025-07-11

#### Fixed:
- Re-deployed version 8.3.0 to ensure all files and assets were correctly included in the WordPress.org release.
- Resolved issues with missing or outdated plugin metadata in the initial 8.3.0 deployment.

This patch ensures the renamed and rebranded plugin is properly distributed under the new name **TaxCloud for WooCommerce**.
