### PR TITLE
Add - New Settings to Enable Real-time tax calculation

### DIFF
--- a/includes/abstracts/class-sst-abstract-cart.php
+++ b/includes/abstracts/class-sst-abstract-cart.php
@@ -59,6 +59,12 @@ abstract class SST_Abstract_Cart {
 			return false;
 		}
 
+		// Real-time tax calculation is disabled?.
+		if ( 'yes' === SST_Settings::get( 'disable_real_time_calc' )) {
+			SST_Logger::add( 'Real-time tax calculation is disabled in plugin settings. Skipping lookup.' );
+			return false;
+		}
+
 		// Perform tax lookup(s).
 		foreach ( $this->do_lookup() as $package ) {
 			$response = $package['response'];

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -278,6 +278,20 @@ class SST_Settings {
 				),
 				'desc_tip'    => true,
 			),
+			'disable_real_time_calc' => array(
+				'title'       => __( 'Disable Real-Time Tax Calculation', 'simple-sales-tax' ),
+				'type'        => 'select',
+				'options'     => array(
+					'no'  => __( 'No', 'simple-sales-tax' ),
+					'yes' => __( 'Yes', 'simple-sales-tax' ),
+				),
+				'default'     => 'no',
+				'description' => __(
+					'If enabled, real-time sales tax calculations will be disabled during cart and checkout',
+					'simple-sales-tax'
+				),
+				'desc_tip'    => true,
+			),
 			'tax_based_on'                => array(
 				'title'       => __( 'Tax Based On', 'simple-sales-tax' ),
 				'type'        => 'select',


### PR DESCRIPTION
### Summary

This PR adds a new setting to the Simple Sales Tax plugin that allows merchants to **disable real-time tax calculation** during cart and checkout. This is useful for:

- Merchants who prefer to calculate taxes manually or at a later stage
- Debugging or staging environments

---

### Changes

- Added `disable_real_time_calc` setting field under the Advanced Settings section
- Default value is `no` (real-time calc enabled)
- Updated description to be clear and user-friendly

---

### Next Steps

In future updates, this setting can be used to:
- Prevent real-time API calls to TaxCloud when disabled
- Display conditional admin notices or upgrade prompts
