### PR TITLE
DEV-5564 Fix - Update product price filter to include item context for composite products

### DIFF
--- a/includes/abstracts/class-sst-abstract-cart.php
+++ b/includes/abstracts/class-sst-abstract-cart.php
@@ -216,7 +216,7 @@ abstract class SST_Abstract_Cart {
 			}
 
 			/* Give devs a chance to change the taxable product price. */
-			$price = apply_filters( 'wootax_product_price', $price, $item['data'] );
+			$price = apply_filters( 'wootax_product_price', $price, $item['data'], $item );
 
 			$cart_items[]     = new TaxCloud\CartItem(
 				count( $cart_items ),

--- a/includes/integrations/class-sst-composite-products.php
+++ b/includes/integrations/class-sst-composite-products.php
@@ -15,7 +15,7 @@ class SST_Composite_Products {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'wootax_product_price', array( $this, 'filter_composite_product_price' ), 10, 2 );
+		add_filter( 'wootax_product_price', array( $this, 'filter_composite_product_price' ), 10, 3 );
 	}
 
 	/**
@@ -29,8 +29,22 @@ class SST_Composite_Products {
 	 *
 	 * @return float
 	 */
-	public function filter_composite_product_price( $price, $product ) {
-		if ( is_a( $product, 'WC_Product_Composite' ) ) {
+	public function filter_composite_product_price( $price, $product, $item ) {
+
+		/**
+		 * Get the order item ID.
+		 */
+		$order_item_id = isset( $item['key'] ) ? intval( $item['key'] ) : 0;
+
+		/**
+		 * Check if this item has a composite parent.
+		 */
+		$composite_parent = wc_get_order_item_meta( $order_item_id, '_composite_parent', true );
+
+		/**
+		 * If this item has a composite parent, set its taxable price to zero.
+		 */
+		if ( ! empty( $composite_parent ) ) {
 			$price = 0.0;
 		}
 


### PR DESCRIPTION
https://taxcloud.atlassian.net/browse/DEV-5564
- Remove old conditions of checking WC_Product_Composite
- Added new condition for checking Composite Product
- Add zero price for Composite Product child items only
- Exclude Composite Product  main item

---
Description:  I’ve applied a fix that works for all users, including existing ones.

The composite product checking condition was written over 5 years ago. It no longer works correctly, as the price is being set to 0 for the main composite product instead of only its child items.

Additionally, the second parameter of the `wootax_product_price` filter no longer passes the `$product` object. To resolve this, I’ve introduced a third parameter that passes $item as the cart item.

Later, we can use this `$item` parameter to check the full order object if needed.

In this fix, I’ve checked the `_composite_parent` order item meta, which is unique to composite product child items, and overridden the existing condition accordingly.