### PR TITLE
Bump version to 8.3.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,15 @@
 Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- [8.3.4] - 2025-09-13 =
+
+Fixed:
+- Added: Option to Show Zero Tax on Order Page
+- Added: Better logging
+- Cache verified address only
+- Added: PHP 8.2x support
+
+
 - [8.3.3] - 2025-09-01 =
 
 Fixed:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- [8.3.3] - 2025-09-01 =
+
+Fixed:
+- Tax calculation failures
+- Remove unhooked submenu code
+
 - [8.3.2] - 2025-01-27 =
 
 Added:

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,10 +4,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 - [8.3.4] - 2025-09-13 =
 
 Fixed:
-- Added: Option to Show Zero Tax on Order Page
-- Added: Better logging
-- Cache verified address only
-- Added: PHP 8.2x support
+- PHP 8.2x support
+- Logging
+
+Added:
+- Option: Show Zero Tax on Order Page
+- Force Tax Lookup
+- Option: Cache verified address only
 
 
 - [8.3.3] - 2025-09-01 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,8 +9,8 @@ Fixed:
 
 Added:
 - Option: Show Zero Tax on Order Page
-- Force Tax Lookup
-- Option: Cache verified address only
+- Option: Force Tax Lookup
+- Cache verified address only
 
 
 - [8.3.3] - 2025-09-01 =

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.3.2';
+	    public $version = '8.3.3';
 
 	/**
 	 * The singleton plugin instance.

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.3.3';
+	    public $version = '8.3.4';
 
 	/**
 	 * The singleton plugin instance.

--- a/includes/class-sst-logger.php
+++ b/includes/class-sst-logger.php
@@ -80,7 +80,7 @@ class SST_Logger {
 	 * @param string $message Log message.
 	 * @param array  $context Log context.
 	 *
-	 * @since 8.3.3
+	 * @since 8.3.4
 	 */
 	public static function debug( $message, $context = array() ) {
 		if ( ! is_null( self::$logger ) ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.8
-Stable tag: 8.3.3
+Stable tag: 8.3.4
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.8
-Stable tag: 8.3.2
+Stable tag: 8.3.3
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.3.3
+ * Version:              8.3.4
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.3.2
+ * Version:              8.3.3
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later


### PR DESCRIPTION
- [8.3.4] - 2025-09-13 =

Fixed:
- PHP 8.2x support
- Logging

Added:
- Option: Show Zero Tax on Order Page
- Option: Force Tax Lookup
- Cache verified address only