### PR TITLE
DEV-6055 - Fix: Compatibility with Dokan Multivendor Plugin

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -212,20 +212,3 @@ p[class*="variable_tax_class"] {
     list-style: disc;
     padding-left: 1.5rem;
 }
-
-/* Admin Notice */
-.taxcloud-notice {
-    display: flex;
-    align-items: center;
-    padding-top: 10px !important;
-    padding-bottom: 10px !important;
-}
-
-.txc-notice-icon {
-    margin-right: 10px;
-    height: 50px;
-}
-
-.txc-notice-message p{
-    margin-top: 0;
-}

--- a/includes/abstracts/class-sst-abstract-cart.php
+++ b/includes/abstracts/class-sst-abstract-cart.php
@@ -139,7 +139,8 @@ abstract class SST_Abstract_Cart {
 					__(
 						'Failed to calculate sales tax: Shipping origin address is invalid.',
 						'simple-sales-tax'
-					)
+					),
+					$package
 				);
 				continue;
 			}
@@ -465,6 +466,20 @@ abstract class SST_Abstract_Cart {
 	 * @since 7.0.2
 	 */
 	protected function is_origin_valid( $package ) {
+		// Debug: Check if valid origin
+		SST_Logger::add(
+			__(
+				'Checking package origin address validity',
+				'simple-sales-tax'
+			),
+			array(
+				'isset' => isset( $package['origin'] ),
+				'type'  => is_a( $package['origin'], 'TaxCloud\Address' ),
+				'instanceof' => isset( $package['origin'] ) && $package['origin'] instanceof TaxCloud\Address,
+			)
+		);
+
+		// Return
 		return (
 			isset( $package['origin'] ) &&
 			$package['origin'] instanceof TaxCloud\Address

--- a/includes/abstracts/class-sst-marketplace-integration.php
+++ b/includes/abstracts/class-sst-marketplace-integration.php
@@ -302,4 +302,26 @@ abstract class SST_Marketplace_Integration {
      */
     abstract public function get_seller_address( $seller_id );
 
+    /**
+     * Validates whether the given address has the required fields
+     * to be used as an origin address.
+     *
+     * @param array $address Address components.
+     *
+     * @return bool
+     */
+    public function is_valid_origin( $address ) {
+        
+        /**
+         * TODO: 
+         * - Check for US country since TaxCloud only supports US addresses.
+         * - Should we validate using TaxCloud Address validation API?
+         */
+
+        return ! empty( $address['address'] ) &&
+               ! empty( $address['city'] ) &&
+               ! empty( $address['state'] ) &&
+               ! empty( $address['postcode'] );
+    }
+
 }

--- a/includes/abstracts/class-sst-marketplace-integration.php
+++ b/includes/abstracts/class-sst-marketplace-integration.php
@@ -311,10 +311,10 @@ abstract class SST_Marketplace_Integration {
      * @return bool
      */
     public function is_valid_origin( $address ) {
-        
         /**
          * TODO: 
          * - Check for US country since TaxCloud only supports US addresses.
+         * - If country is not US, should we consider it invalid?
          * - Should we validate using TaxCloud Address validation API?
          */
 

--- a/includes/abstracts/class-sst-marketplace-integration.php
+++ b/includes/abstracts/class-sst-marketplace-integration.php
@@ -316,6 +316,7 @@ abstract class SST_Marketplace_Integration {
          * - Check for US country since TaxCloud only supports US addresses.
          * - If country is not US, should we consider it invalid?
          * - Should we validate using TaxCloud Address validation API?
+         * - Should we notify the seller/admin if the address is invalid?
          */
 
         return ! empty( $address['address'] ) &&

--- a/includes/abstracts/class-sst-marketplace-integration.php
+++ b/includes/abstracts/class-sst-marketplace-integration.php
@@ -309,16 +309,9 @@ abstract class SST_Marketplace_Integration {
      * @param array $address Address components.
      *
      * @return bool
+     * @see https://github.com/FedTax/simplesalestax/pull/388
      */
     public function is_valid_origin( $address ) {
-        /**
-         * TODO: 
-         * - Check for US country since TaxCloud only supports US addresses.
-         * - If country is not US, should we consider it invalid?
-         * - Should we validate using TaxCloud Address validation API?
-         * - Should we notify the seller/admin if the address is invalid?
-         */
-
         return ! empty( $address['address'] ) &&
                ! empty( $address['city'] ) &&
                ! empty( $address['state'] ) &&

--- a/includes/admin/class-sst-admin.php
+++ b/includes/admin/class-sst-admin.php
@@ -398,6 +398,21 @@ class SST_Admin {
         });
 			});
 		</script>
+		<style>
+			.taxcloud-notice {
+				display: flex;
+				align-items: center;
+				padding-top: 10px !important;
+				padding-bottom: 10px !important;
+			}
+			.txc-notice-icon {
+				margin-right: 10px;
+				height: 50px;
+			}
+			.txc-notice-message p{
+				margin-top: 0;
+			}
+		</style>
 		<?php
 	}
 

--- a/includes/class-sst-origin-address.php
+++ b/includes/class-sst-origin-address.php
@@ -109,7 +109,7 @@ class SST_Origin_Address extends Address {
 	 * @param string $Zip4 4 digit component of ZIP code.
 	 */
 	public function setZip4( $Zip4 ) {
-		$this->Zip4 = substr( $Zip4, 0, 4 );
+		$this->Zip4 = substr( (string) $Zip4, 0, 4 );
 	}
 
 }

--- a/includes/integrations/class-sst-dokan.php
+++ b/includes/integrations/class-sst-dokan.php
@@ -243,6 +243,11 @@ class SST_Dokan extends SST_Marketplace_Integration {
 		}
 
 		try {
+			// Validate the address.
+			if ( !$this->is_valid_origin( $address ) ) {
+				throw new Exception( __( 'Incomplete origin address.', 'simple-sales-tax' ) );	
+			}
+
 			return new SST_Origin_Address(
 				"S-{$seller_id}",
 				false,
@@ -253,7 +258,12 @@ class SST_Dokan extends SST_Marketplace_Integration {
 				$address['postcode']
 			);
 		} catch ( Exception $ex ) {
-			SST_Logger::add( "Error encountered while constructing origin address for seller {$seller_id}: {$ex->getMessage()}. Falling back to default store origin." );
+			// Log the error with debug context.
+			SST_Logger::add( sprintf( __( 'Failed to get origin address for seller %d: %s.', 'simple-sales-tax' ), $seller_id, $ex->getMessage() ), array(
+				'source' => 'dokan',
+				'seller_address' => $address,
+				'seller_id' => $seller_id
+			) );
 
 			return SST_Addresses::get_default_address();
 		}

--- a/includes/integrations/class-sst-dokan.php
+++ b/includes/integrations/class-sst-dokan.php
@@ -259,7 +259,7 @@ class SST_Dokan extends SST_Marketplace_Integration {
 			);
 		} catch ( Exception $ex ) {
 			// Log the error with debug context.
-			SST_Logger::add( sprintf( __( 'Failed to get origin address for seller %d: %s.', 'simple-sales-tax' ), $seller_id, $ex->getMessage() ), array(
+			SST_Logger::add( sprintf( __( 'Failed to get origin address for seller %d: %s. Falling back to default store origin.', 'simple-sales-tax' ), $seller_id, $ex->getMessage() ), array(
 				'source' => 'dokan',
 				'seller_address' => $address,
 				'seller_id' => $seller_id


### PR DESCRIPTION
Validates whether the seller’s address contains the necessary fields. If the address is invalid, it applies a default origin address.

**Checklist:**
- Ensure the address is in the US, as TaxCloud only supports US addresses.
- If the address is not in the US, should we consider it invalid?
- If the country is invalid, should we apply a default origin address or stop calculating tax?
- Should we use TaxCloud Address validation API for validation?
- Should we notify the seller or admin if the address is invalid?
- - Should we notify the seller via email?
- - Should we notify the seller in the vendor dashboard?