### PR TITLE
DEV-5366: Force "disable real time calc" for non-premium users in woo plugin

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -212,3 +212,8 @@ p[class*="variable_tax_class"] {
     list-style: disc;
     padding-left: 1.5rem;
 }
+
+.d-flex {
+    display: flex;
+    gap: 10px;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -81,5 +81,35 @@
           $btn.prop('disabled', false);
         });
     });
+
+    // Refresh integration mode
+    jQuery(document).on('click', '.sst-update-data-mover', function (e) {
+      e.preventDefault();
+      var $btn = jQuery(this).prop('disabled', true).addClass('is-busy');
+      var nonce = jQuery(this).data('nonce');
+
+      jQuery.post(ajaxurl, {
+        action: 'sst_update_data_mover',
+        _wpnonce: nonce,
+      })
+        .done(function (resp) {
+          if (resp.success) {
+            var integrationMode = resp.data.integration_mode;
+            jQuery('#woocommerce_wootax_integration_mode').val(integrationMode);
+            alert(data.strings.mode_refreshed + integrationMode);
+          } else {
+            alert(data.strings.went_wrong);
+          }
+        })
+        .fail(function (xhr, status, error) {
+          console.error('AJAX POST failed:', xhr, status, error);
+          alert(data.strings.went_wrong);
+        })
+        .always(function () {
+          // Re-enable button after request
+          $btn.prop('disabled', false).removeClass('is-busy');
+        });
+    });
+
   });
 })(SST);

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -452,7 +452,7 @@ class SST_Integration extends WC_Integration {
 								value="<?php echo esc_attr( $integration_mode ); ?>"
 								readonly="readonly"
 								disabled="disabled">
-								<button type="button" class="components-button is-secondary sst-update-data-mover">
+								<button type="button" class="components-button is-secondary sst-update-data-mover" data-nonce="<?php echo wp_create_nonce( 'sst-update-data-mover-nonce' ); ?>">
 									<span class="dashicons dashicons-update"></span>
 									<?php echo wp_kses_post( __( 'Refresh', 'simple-sales-tax' ) ); ?>
 								</button>

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -411,4 +411,54 @@ class SST_Integration extends WC_Integration {
 		$updater->save()->dispatch();
 	}
 
+	public function generate_integration_mode_html( $key, $data ) {
+		$field            = "{$this->plugin_id}{$this->id}_{$key}";
+		$api_id           = SST_Settings::get( 'tc_id' );
+		$api_key          = SST_Settings::get( 'tc_key' );
+		$data_mover       = SST_Settings::get( 'data_mover', false );
+
+		$integration_mode = $data_mover == false ? __( 'Premium', 'simple-sales-tax' ) : __( 'Basic', 'simple-sales-tax' );
+
+		ob_start();
+		?>
+		<tr valign="top">
+			<th scope="row" class="titledesc">
+				<label for="<?php echo esc_attr( $field ); ?>">
+					<?php echo wp_kses_post( $data['title'] ); ?><?php echo wp_kses_post( $this->get_tooltip_html( $data ) ); ?>
+				</label>
+			</th>
+			<td class="forminp">
+				<fieldset>
+					<legend class="screen-reader-text">
+						<span><?php echo wp_kses_post( $data['title'] ); ?></span>
+					</legend>
+					<?php if ( ! empty( $api_id ) && ! empty( $api_key ) ): ?>
+						<input type="text"
+							value="<?php echo esc_attr( $integration_mode ); ?>"
+							readonly="readonly"
+							disabled="disabled">						
+					<?php else: ?>
+						<div class="notice notice-info inline sst-settings-notice">
+							<p>
+								<?php
+								echo wp_kses_post(
+									__(
+										'Enter your TaxCloud API credentials and click <strong>Save changes</strong> to display the Integration Mode.',
+										'simple-sales-tax'
+									)
+								);
+								?>
+							</p>
+						</div>
+					<?php endif; ?>
+					<?php echo wp_kses_post( $this->get_description_html( $data ) ); ?>
+				</fieldset>
+			</td>
+		</tr>
+		<?php
+
+		return ob_get_clean();
+	}
+	
+
 }

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -36,6 +36,7 @@ class SST_Integration extends WC_Integration {
 		// Register action hooks.
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'refresh_origin_address_list' ), 15 );
+		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'update_data_mover_settings' ), 20 );
 		add_action( 'admin_init', array( $this, 'maybe_download_debug_report' ) );
 		add_action( 'woocommerce_hide_sst_address_mismatch_notice', array( $this, 'maybe_dismiss_address_notice' ) );
 	}
@@ -411,6 +412,14 @@ class SST_Integration extends WC_Integration {
 		$updater->save()->dispatch();
 	}
 
+	/**
+	 * Generates the integration mode HTML.
+	 *
+	 * @param string $key  The field key.
+	 * @param array  $data The field data.
+	 *
+	 * @return string The integration mode HTML.
+	 */
 	public function generate_integration_mode_html( $key, $data ) {
 		$field            = "{$this->plugin_id}{$this->id}_{$key}";
 		$api_id           = SST_Settings::get( 'tc_id' );
@@ -421,10 +430,14 @@ class SST_Integration extends WC_Integration {
 
 		ob_start();
 		?>
+		
 		<tr valign="top">
 			<th scope="row" class="titledesc">
 				<label for="<?php echo esc_attr( $field ); ?>">
-					<?php echo wp_kses_post( $data['title'] ); ?><?php echo wp_kses_post( $this->get_tooltip_html( $data ) ); ?>
+					<?php echo wp_kses_post( $data['title'] ); ?>
+					<?php if ( ! empty( $api_id ) && ! empty( $api_key ) ): ?>
+						<?php echo wp_kses_post( $this->get_tooltip_html( $data ) ); ?>
+					<?php endif; ?>
 				</label>
 			</th>
 			<td class="forminp">
@@ -433,10 +446,32 @@ class SST_Integration extends WC_Integration {
 						<span><?php echo wp_kses_post( $data['title'] ); ?></span>
 					</legend>
 					<?php if ( ! empty( $api_id ) && ! empty( $api_key ) ): ?>
-						<input type="text"
-							value="<?php echo esc_attr( $integration_mode ); ?>"
-							readonly="readonly"
-							disabled="disabled">						
+						<div class="d-flex">
+							<input type="text"
+								id="<?php echo esc_attr( $field ); ?>"
+								value="<?php echo esc_attr( $integration_mode ); ?>"
+								readonly="readonly"
+								disabled="disabled">
+								<button type="button" class="components-button is-secondary sst-update-data-mover">
+									<span class="dashicons dashicons-update"></span>
+									<?php echo wp_kses_post( __( 'Refresh', 'simple-sales-tax' ) ); ?>
+								</button>
+						</div>
+						<div class="description">
+							<p>
+								<?php
+								echo wp_kses_post(
+									__(
+										'Premium users can calculate tax in real-time while Basic users can only do data import to TaxCloud.',
+										'simple-sales-tax'
+									)
+								);
+								?>
+								<a href="https://taxcloud.com/go/configure" target="_blank">
+									<?php echo wp_kses_post( __( 'Configure in TaxCloud', 'simple-sales-tax' ) ); ?>
+								</a>
+							</p>
+						</div>
 					<?php else: ?>
 						<div class="notice notice-info inline sst-settings-notice">
 							<p>
@@ -456,8 +491,14 @@ class SST_Integration extends WC_Integration {
 			</td>
 		</tr>
 		<?php
-
 		return ob_get_clean();
+	}
+
+	/**
+	 * Updates the data mover settings.
+	 */
+	public function update_data_mover_settings() {
+		SST_TaxCloud_V3::update_data_mover_settings();
 	}
 	
 

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -467,7 +467,7 @@ class SST_Integration extends WC_Integration {
 									)
 								);
 								?>
-								<a href="https://taxcloud.com/go/configure" target="_blank">
+								<a href="https://app.taxcloud.com/go/integrations" target="_blank">
 									<?php echo wp_kses_post( __( 'Configure in TaxCloud', 'simple-sales-tax' ) ); ?>
 								</a>
 							</p>

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -498,8 +498,7 @@ class SST_Integration extends WC_Integration {
 	 * Updates the data mover settings.
 	 */
 	public function update_data_mover_settings() {
-		SST_TaxCloud_V3::update_data_mover_settings();
+		SST_TaxCloud_V3_API::update_data_mover_settings();
 	}
-	
 
 }

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -138,6 +138,7 @@ final class SimpleSalesTax {
 		require_once __DIR__ . '/class-sst-assets.php';
 		require_once __DIR__ . '/class-sst-marketplaces.php';
 		require_once __DIR__ . '/class-sst-blocks.php';
+		require_once __DIR__ . '/class-sst-taxcloud-v3.php';
 
 		/**
 		 * Third party integrations.

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -138,6 +138,7 @@ final class SimpleSalesTax {
 		require_once __DIR__ . '/class-sst-assets.php';
 		require_once __DIR__ . '/class-sst-marketplaces.php';
 		require_once __DIR__ . '/class-sst-blocks.php';
+		require_once __DIR__ . '/class-sst-taxcloud-v3-api.php';
 		require_once __DIR__ . '/class-sst-taxcloud-v3.php';
 
 		/**

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -79,6 +79,10 @@ class SST_Ajax {
 		} else {
 			try {
 				TaxCloud()->Ping( new TaxCloud\Request\Ping( $taxcloud_id, $taxcloud_key ) );
+
+				// Ping successful, update data mover settings
+				$data_mover_settings = SST_TaxCloud_V3::update_data_mover_settings( $taxcloud_id, $taxcloud_key );
+
 				wp_send_json_success();
 			} catch ( Exception $ex ) {
 				wp_send_json_error( $ex->getMessage() );

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -29,6 +29,7 @@ class SST_Ajax {
 		'sst_get_certificates'        => false,
 		'sst_dismiss_taxcloud_notice'	=> false,
 		'sst_get_order_log'						=> false,
+		'sst_update_data_mover'				=> false,
 	);
 
 	/**
@@ -356,6 +357,25 @@ class SST_Ajax {
 		wp_send_json_success();
 	}
 
+	/**
+	 * Update Data Mover settings.
+	 *
+	 * @since 8.3.5
+	 */
+	public static function update_data_mover() {
+		// Verify nonce.
+		check_ajax_referer( 'sst-update-data-mover-nonce' );
+
+		// Update data mover settings
+		SST_TaxCloud_V3::update_data_mover_settings();
+
+		// Get data mover settings
+		$data_mover = SST_Settings::get( 'data_mover', false );
+		$integration_mode = $data_mover == false ? __( 'Premium', 'simple-sales-tax' ) : __( 'Basic', 'simple-sales-tax' );
+
+		// Response
+		wp_send_json_success( [ 'integration_mode' => $integration_mode, 'data_mover' => $data_mover ] );
+	}
 
 }
 

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -82,7 +82,7 @@ class SST_Ajax {
 				TaxCloud()->Ping( new TaxCloud\Request\Ping( $taxcloud_id, $taxcloud_key ) );
 
 				// Ping successful, update data mover settings
-				$data_mover_settings = SST_TaxCloud_V3::update_data_mover_settings( $taxcloud_id, $taxcloud_key );
+				$data_mover_settings = SST_TaxCloud_V3_API::update_data_mover_settings( $taxcloud_id, $taxcloud_key );
 
 				wp_send_json_success();
 			} catch ( Exception $ex ) {
@@ -367,7 +367,7 @@ class SST_Ajax {
 		check_ajax_referer( 'sst-update-data-mover-nonce' );
 
 		// Update data mover settings
-		SST_TaxCloud_V3::update_data_mover_settings();
+		SST_TaxCloud_V3_API::update_data_mover_settings();
 
 		// Get data mover settings
 		$data_mover = SST_Settings::get( 'data_mover', false );

--- a/includes/class-sst-assets.php
+++ b/includes/class-sst-assets.php
@@ -109,6 +109,7 @@ class SST_Assets {
 								'verify_btn'       => __( 'Verify Settings', 'simple-sales-tax' ),
 								'verifying'        => __( 'Verifying...', 'simple-sales-tax' ),
 								'went_wrong'      => __( 'Something went wrong.', 'simple-sales-tax' ),
+								'mode_refreshed'   => __( 'Success! Your integration mode is now ', 'simple-sales-tax' ),
 							),
 						),
 					),

--- a/includes/class-sst-install.php
+++ b/includes/class-sst-install.php
@@ -82,6 +82,7 @@ class SST_Install {
 	 */
 	public static function deactivate() {
 		self::remove_notices();
+		self::remove_cron();
 	}
 
 	/**
@@ -380,6 +381,13 @@ class SST_Install {
 		if ( sst_wcms_active() ) {
 			remove_filter( 'woocommerce_order_get_items', array( $GLOBALS['wcms']->order, 'order_item_taxes' ), 30 );
 		}
+	}
+
+	/**
+	 * Remove cron job.
+	 */
+	public static function remove_cron() {
+		wp_clear_scheduled_hook( 'sst_update_data_mover_settings' );
 	}
 }
 

--- a/includes/class-sst-marketplaces.php
+++ b/includes/class-sst-marketplaces.php
@@ -65,7 +65,7 @@ class SST_Marketplaces {
 			// Hide the origin address dropdown. We always use the vendor's
 			// address as the origin address in the marketplace setting.
 			add_filter( 'sst_show_origin_address_dropdown', '__return_false' );
-			add_filter( 'sst_settings_form_fields', array( $this, 'change_origin_addresses_description' ) );
+			add_filter( 'sst_settings_form_fields', array( $this, 'change_origin_addresses_description' ), 10, 2 );
 		}
 	}
 
@@ -110,7 +110,7 @@ class SST_Marketplaces {
 	 *
 	 * @return array
 	 */
-	public function change_origin_addresses_description( $fields ) {
+	public function change_origin_addresses_description( $fields, $settings ) {
 		if ( ! isset( $fields['default_origin_addresses'] ) ) {
 			return $fields;
 		}

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -385,7 +385,7 @@ class SST_Settings {
 			),
 		);
 
-		return apply_filters( 'sst_settings_form_fields', $fields );
+		return apply_filters( 'sst_settings_form_fields', $fields, self::get_settings() );
 	}
 
 	/**
@@ -465,6 +465,19 @@ class SST_Settings {
 		}
 
 		return $wp_roles->get_names();
+	}
+
+	/**
+	 * Get SST settings
+	 *
+	 * @return array
+	 */
+	public static function get_settings() {
+		if ( empty( self::$settings ) ) {
+			self::load_settings();
+		}
+
+		return self::$settings;
 	}
 
 }

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -436,7 +436,7 @@ class SST_Settings {
 			self::$settings[ $key ] = $empty_value;
 		}
 
-		return self::$settings[ $key ];
+		return apply_filters( 'sst_get_option', self::$settings[ $key ], $key );
 	}
 
 	/**

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -123,6 +123,16 @@ class SST_Settings {
 				'desc_tip'    => true,
 				'id'          => 'verifySettings',
 			),
+			'integration_mode'            => array(
+				'title'       => __( 'Integration Mode', 'simple-sales-tax' ),
+				'type'        => 'integration_mode',
+				'default'     => '',
+				'desc_tip'    => false,
+				'custom_attributes' => array(
+					'readonly' => 'readonly',
+					'disabled' => 'disabled',
+				),
+			),
 			'address_settings'            => array(
 				'title'       => __( 'Address Settings', 'simple-sales-tax' ),
 				'type'        => 'title',

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -83,6 +83,8 @@ class SST_Settings {
 			self::is_using_checkout_block()
 		);
 
+		$disable_realtime_calc = self::get( 'data_mover', false );
+
 		$fields = array(
 			'taxcloud_settings'           => array(
 				'title'       => __( 'TaxCloud Settings', 'simple-sales-tax' ),
@@ -345,6 +347,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
+				'disabled'    => $disable_realtime_calc,
 			),
 			'tax_based_on'                => array(
 				'title'       => __( 'Tax Based On', 'simple-sales-tax' ),

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -127,7 +127,11 @@ class SST_Settings {
 				'title'       => __( 'Integration Mode', 'simple-sales-tax' ),
 				'type'        => 'integration_mode',
 				'default'     => '',
-				'desc_tip'    => false,
+				'desc_tip'    => true,
+				'description' => __(
+					'Click the refresh button to check TaxCloud for the current mode setting.',
+					'simple-sales-tax'
+				),
 				'custom_attributes' => array(
 					'readonly' => 'readonly',
 					'disabled' => 'disabled',

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -83,8 +83,6 @@ class SST_Settings {
 			self::is_using_checkout_block()
 		);
 
-		$disable_realtime_calc = self::get( 'data_mover', false );
-
 		$fields = array(
 			'taxcloud_settings'           => array(
 				'title'       => __( 'TaxCloud Settings', 'simple-sales-tax' ),
@@ -347,7 +345,6 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
-				'disabled'    => $disable_realtime_calc,
 			),
 			'tax_based_on'                => array(
 				'title'       => __( 'Tax Based On', 'simple-sales-tax' ),

--- a/includes/class-sst-taxcloud-v3-api.php
+++ b/includes/class-sst-taxcloud-v3-api.php
@@ -152,7 +152,7 @@ class SST_TaxCloud_V3_API {
 	 * @return array|WP_Error Settings array on success, WP_Error on failure.
 	 */
 	public static function update_data_mover_settings( $api_login_id = null, $api_key = null ) {
-		if ( ! $api_login_id || ! $api_key ) {
+		if ( !$api_login_id || !$api_key ) {
 			$api_login_id	= SST_Settings::get( 'tc_id' );
 			$api_key			= SST_Settings::get( 'tc_key' );
 		}

--- a/includes/class-sst-taxcloud-v3-api.php
+++ b/includes/class-sst-taxcloud-v3-api.php
@@ -1,0 +1,182 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * TaxCloud v3 API Client.
+ *
+ * Handles authentication and settings retrieval from TaxCloud v3 API.
+ *
+ * @author  Simple Sales Tax
+ * @package SST
+ * @since   8.4.0
+ */
+class SST_TaxCloud_V3_API {
+
+	/**
+	 * API Base URLs.
+	 */
+	const STAGING_AUTH_URL = 'https://staging-taxcloudapi.azurewebsites.net/api/v3/auth/token';
+	const PROD_AUTH_URL    = 'https://taxcloudapi-appservice-core-prod.azurewebsites.net/api/v3/auth/token';
+	const STAGING_MGMT_URL = 'https://api.v3.taxcloud.net/mgmt';
+	const PROD_MGMT_URL    = 'https://api.v3.taxcloud.com/mgmt';
+
+	/**
+	 * Get the appropriate Auth URL based on environment.
+	 *
+	 * @return string
+	 */
+	private static function get_auth_url() {
+		// For now, we'll default to PROD unless a constant is defined for staging.
+		// In the future, this could be a setting.
+		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
+			return self::STAGING_AUTH_URL;
+		}
+		return self::PROD_AUTH_URL;
+	}
+
+	/**
+	 * Get the appropriate Management URL based on environment.
+	 *
+	 * @return string
+	 */
+	private static function get_mgmt_url() {
+		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
+			return self::STAGING_MGMT_URL;
+		}
+		return self::PROD_MGMT_URL;
+	}
+
+	/**
+	 * Exchange v1 credentials for v3 Bearer token.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return string|WP_Error Access token on success, WP_Error on failure.
+	 */
+	public static function get_auth_token( $api_login_id, $api_key ) {
+		$url = self::get_auth_url();
+
+		$response = wp_remote_post( $url, array(
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
+			'body'    => json_encode( array(
+				'apiLoginID' => $api_login_id,
+				'apiKey'     => $api_key,
+			) ),
+			'timeout' => 30,
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( $code >= 400 ) {
+			return new WP_Error( 'sst_v3_auth_error', 'Failed to authenticate with TaxCloud v3 API: ' . ( isset( $data['message'] ) ? $data['message'] : $body ) );
+		}
+
+		if ( empty( $data['access_token'] ) ) {
+			return new WP_Error( 'sst_v3_auth_error', 'No access token received from TaxCloud v3 API.' );
+		}
+
+		return $data['access_token'];
+	}
+
+	/**
+	 * Get connection settings using Bearer token.
+	 *
+	 * @param string $api_key      TaxCloud API Key (used as connection ID).
+	 * @param string $access_token Bearer token.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function get_connection_settings( $api_key, $access_token ) {
+		$url = self::get_mgmt_url() . '/connections/' . $api_key;
+
+		$response = wp_remote_get( $url, array(
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $access_token,
+				'Content-Type'  => 'application/json',
+			),
+			'timeout' => 30,
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( $code === 404 ) {
+			// Connection settings don't exist yet, which is normal for new connections.
+			// Return empty settings.
+			return array();
+		}
+
+		if ( $code >= 400 ) {
+			return new WP_Error( 'sst_v3_settings_error', 'Failed to retrieve connection settings: ' . $body );
+		}
+
+		return json_decode( $body, true );
+	}
+
+	/**
+	 * Get settings using v1 credentials.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function get_settings_with_v1_creds( $api_login_id, $api_key ) {
+		$token = self::get_auth_token( $api_login_id, $api_key );
+
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+
+		return self::get_connection_settings( $api_key, $token );
+	}
+
+	/**
+	 * Update data mover settings using v1 credentials.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function update_data_mover_settings( $api_login_id = null, $api_key = null ) {
+		if ( ! $api_login_id || ! $api_key ) {
+			$api_login_id	= SST_Settings::get( 'tc_id' );
+			$api_key			= SST_Settings::get( 'tc_key' );
+		}
+
+		// Return if empty
+		if ( empty( $api_login_id ) || empty( $api_key ) ) {
+			SST_Logger::add( 'Failed to update data mover settings: API Login ID or API Key is empty' );
+			return;
+		}
+
+		// Add to cronjob to check daily
+		if ( ! wp_next_scheduled( 'sst_update_data_mover_settings' ) ) {
+			wp_schedule_event( time(), 'daily', 'sst_update_data_mover_settings' );
+		}
+
+		// Check v3 settings
+		$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
+
+		if ( ! is_wp_error( $v3_settings ) ) {
+			$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];
+			SST_Settings::set( 'data_mover', $data_mover );
+		} else {
+			// Log error but don't fail verification if v3 fails (optional, depending on strictness)
+			SST_Logger::add( 'Failed to fetch v3 settings: ' . $v3_settings->get_error_message() );
+		}
+	}
+}

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -1,0 +1,170 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * TaxCloud v3 API Client.
+ *
+ * Handles authentication and settings retrieval from TaxCloud v3 API.
+ *
+ * @author  Simple Sales Tax
+ * @package SST
+ * @since   8.4.0
+ */
+class SST_TaxCloud_V3 {
+
+	/**
+	 * API Base URLs.
+	 */
+	const STAGING_AUTH_URL = 'https://staging-taxcloudapi.azurewebsites.net/api/v3/auth/token';
+	const PROD_AUTH_URL    = 'https://taxcloudapi-appservice-core-prod.azurewebsites.net/api/v3/auth/token';
+	const STAGING_MGMT_URL = 'https://api.v3.taxcloud.net/mgmt';
+	const PROD_MGMT_URL    = 'https://api.v3.taxcloud.com/mgmt';
+
+	/**
+	 * Get the appropriate Auth URL based on environment.
+	 *
+	 * @return string
+	 */
+	private static function get_auth_url() {
+		// For now, we'll default to PROD unless a constant is defined for staging.
+		// In the future, this could be a setting.
+		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
+			return self::STAGING_AUTH_URL;
+		}
+		return self::PROD_AUTH_URL;
+	}
+
+	/**
+	 * Get the appropriate Management URL based on environment.
+	 *
+	 * @return string
+	 */
+	private static function get_mgmt_url() {
+		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
+			return self::STAGING_MGMT_URL;
+		}
+		return self::PROD_MGMT_URL;
+	}
+
+	/**
+	 * Exchange v1 credentials for v3 Bearer token.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return string|WP_Error Access token on success, WP_Error on failure.
+	 */
+	public static function get_auth_token( $api_login_id, $api_key ) {
+		$url = self::get_auth_url();
+
+		$response = wp_remote_post( $url, array(
+			'headers' => array(
+				'Content-Type' => 'application/json',
+			),
+			'body'    => json_encode( array(
+				'apiLoginID' => $api_login_id,
+				'apiKey'     => $api_key,
+			) ),
+			'timeout' => 30,
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+		$data = json_decode( $body, true );
+
+		if ( $code >= 400 ) {
+			return new WP_Error( 'sst_v3_auth_error', 'Failed to authenticate with TaxCloud v3 API: ' . ( isset( $data['message'] ) ? $data['message'] : $body ) );
+		}
+
+		if ( empty( $data['access_token'] ) ) {
+			return new WP_Error( 'sst_v3_auth_error', 'No access token received from TaxCloud v3 API.' );
+		}
+
+		// error_log( print_r( $data, true ) );
+
+		return $data['access_token'];
+	}
+
+	/**
+	 * Get connection settings using Bearer token.
+	 *
+	 * @param string $api_key      TaxCloud API Key (used as connection ID).
+	 * @param string $access_token Bearer token.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function get_connection_settings( $api_key, $access_token ) {
+		$url = self::get_mgmt_url() . '/connections/' . $api_key;
+
+		$response = wp_remote_get( $url, array(
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $access_token,
+				'Content-Type'  => 'application/json',
+			),
+			'timeout' => 30,
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( $code === 404 ) {
+			// Connection settings don't exist yet, which is normal for new connections.
+			// Return empty settings.
+			return array();
+		}
+
+		if ( $code >= 400 ) {
+			return new WP_Error( 'sst_v3_settings_error', 'Failed to retrieve connection settings: ' . $body );
+		}
+
+		return json_decode( $body, true );
+	}
+
+	/**
+	 * Get settings using v1 credentials.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function get_settings_with_v1_creds( $api_login_id, $api_key ) {
+		$token = self::get_auth_token( $api_login_id, $api_key );
+
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
+
+		return self::get_connection_settings( $api_key, $token );
+	}
+
+	/**
+	 * Update data mover settings using v1 credentials.
+	 *
+	 * @param string $api_login_id TaxCloud API Login ID.
+	 * @param string $api_key      TaxCloud API Key.
+	 * @return array|WP_Error Settings array on success, WP_Error on failure.
+	 */
+	public static function update_data_mover_settings( $api_login_id, $api_key ) {
+			// Check v3 settings
+			$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
+
+			error_log( print_r( $v3_settings, true ) );
+
+			if ( ! is_wp_error( $v3_settings ) ) {
+				$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];
+				SST_Settings::set( 'data_mover', $data_mover );
+			} else {
+				// Log error but don't fail verification if v3 fails (optional, depending on strictness)
+				SST_Logger::add( 'Failed to fetch v3 settings: ' . $v3_settings->get_error_message() );
+			}
+	}
+}

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -159,10 +159,19 @@ class SST_TaxCloud_V3 {
 			$api_key			= SST_Settings::get( 'tc_key' );
 		}
 
+		// Return if empty
+		if ( empty( $api_login_id ) || empty( $api_key ) ) {
+			SST_Logger::add( 'Failed to update data mover settings: API Login ID or API Key is empty' );
+			return;
+		}
+
+		// Add to cronjob to check daily
+		if ( ! wp_next_scheduled( 'sst_update_data_mover_settings' ) ) {
+			wp_schedule_event( time(), 'daily', 'sst_update_data_mover_settings' );
+		}
+
 		// Check v3 settings
 		$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
-
-		error_log( print_r( $v3_settings, true ) );
 
 		if ( ! is_wp_error( $v3_settings ) ) {
 			$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -40,7 +40,7 @@ class SST_TaxCloud_V3 {
 	 */
 	protected function __construct() {
 		add_action( 'sst_update_data_mover_settings', array( 'SST_TaxCloud_V3_API', 'update_data_mover_settings' ) );
-		add_filter( 'sst_get_option', array( $this, 'sst_update_realtime_calc_option' ), 10, 2 );
+		add_filter( 'sst_get_option', array( $this, 'update_realtime_calc_option' ), 10, 2 );
 		add_filter( 'sst_settings_form_fields', array( $this, 'disable_real_time_calc_option' ) );
 	}
 
@@ -51,8 +51,8 @@ class SST_TaxCloud_V3 {
 	 *
 	 * @return array
 	 */
-	function disable_real_time_calc_option( $fields ) {
-		$data_mover = SST_Settings::get( 'data_mover', false );
+	public function disable_real_time_calc_option( $fields ) {
+		$data_mover = SST_Settings::get( 'data_mover' );
 		if( $data_mover ) {
 			$fields['disable_real_time_calc']['disabled'] =  $data_mover;
 			$fields['disable_real_time_calc']['options'] = array(
@@ -71,7 +71,7 @@ class SST_TaxCloud_V3 {
 	 *
 	 * @return string
 	 */
-	function sst_update_realtime_calc_option( $value, $key ) {
+	public function update_realtime_calc_option( $value, $key ) {
 		if( 'disable_real_time_calc' === $key ) {
 			$data_mover = SST_Settings::get( 'data_mover', false );
 			if( $data_mover ) {

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -153,18 +153,23 @@ class SST_TaxCloud_V3 {
 	 * @param string $api_key      TaxCloud API Key.
 	 * @return array|WP_Error Settings array on success, WP_Error on failure.
 	 */
-	public static function update_data_mover_settings( $api_login_id, $api_key ) {
-			// Check v3 settings
-			$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
+	public static function update_data_mover_settings( $api_login_id = null, $api_key = null ) {
+		if ( ! $api_login_id || ! $api_key ) {
+			$api_login_id	= SST_Settings::get( 'tc_id' );
+			$api_key			= SST_Settings::get( 'tc_key' );
+		}
 
-			error_log( print_r( $v3_settings, true ) );
+		// Check v3 settings
+		$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
 
-			if ( ! is_wp_error( $v3_settings ) ) {
-				$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];
-				SST_Settings::set( 'data_mover', $data_mover );
-			} else {
-				// Log error but don't fail verification if v3 fails (optional, depending on strictness)
-				SST_Logger::add( 'Failed to fetch v3 settings: ' . $v3_settings->get_error_message() );
-			}
+		error_log( print_r( $v3_settings, true ) );
+
+		if ( ! is_wp_error( $v3_settings ) ) {
+			$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];
+			SST_Settings::set( 'data_mover', $data_mover );
+		} else {
+			// Log error but don't fail verification if v3 fails (optional, depending on strictness)
+			SST_Logger::add( 'Failed to fetch v3 settings: ' . $v3_settings->get_error_message() );
+		}
 	}
 }

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -41,7 +41,7 @@ class SST_TaxCloud_V3 {
 	protected function __construct() {
 		add_action( 'sst_update_data_mover_settings', array( 'SST_TaxCloud_V3_API', 'update_data_mover_settings' ) );
 		add_filter( 'sst_get_option', array( $this, 'update_realtime_calc_option' ), 10, 2 );
-		add_filter( 'sst_settings_form_fields', array( $this, 'disable_real_time_calc_option' ) );
+		add_filter( 'sst_settings_form_fields', array( $this, 'disable_real_time_calc_option' ), 10, 2 );
 	}
 
 	/**
@@ -51,8 +51,8 @@ class SST_TaxCloud_V3 {
 	 *
 	 * @return array
 	 */
-	public function disable_real_time_calc_option( $fields ) {
-		$data_mover = SST_Settings::get( 'data_mover' );
+	public function disable_real_time_calc_option( $fields, $settings ) {
+		$data_mover = isset( $settings['data_mover'] ) ? (bool) $settings['data_mover'] : false;
 		if( $data_mover ) {
 			$fields['disable_real_time_calc']['disabled'] =  $data_mover;
 			$fields['disable_real_time_calc']['options'] = array(

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -86,8 +86,6 @@ class SST_TaxCloud_V3 {
 			return new WP_Error( 'sst_v3_auth_error', 'No access token received from TaxCloud v3 API.' );
 		}
 
-		// error_log( print_r( $data, true ) );
-
 		return $data['access_token'];
 	}
 

--- a/includes/class-sst-taxcloud-v3.php
+++ b/includes/class-sst-taxcloud-v3.php
@@ -5,9 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * TaxCloud v3 API Client.
+ * TaxCloud v3 Client.
  *
- * Handles authentication and settings retrieval from TaxCloud v3 API.
+ * Handles the data v3 settings.
  *
  * @author  Simple Sales Tax
  * @package SST
@@ -16,167 +16,72 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SST_TaxCloud_V3 {
 
 	/**
-	 * API Base URLs.
+	 * Singleton instance.
+	 *
+	 * @var SST_TaxCloud_V3
 	 */
-	const STAGING_AUTH_URL = 'https://staging-taxcloudapi.azurewebsites.net/api/v3/auth/token';
-	const PROD_AUTH_URL    = 'https://taxcloudapi-appservice-core-prod.azurewebsites.net/api/v3/auth/token';
-	const STAGING_MGMT_URL = 'https://api.v3.taxcloud.net/mgmt';
-	const PROD_MGMT_URL    = 'https://api.v3.taxcloud.com/mgmt';
+	protected static $_instance = null;
 
 	/**
-	 * Get the appropriate Auth URL based on environment.
+	 * Singleton instance accessor.
+	 *
+	 * @return SST_TaxCloud_V3
+	 */
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+
+		return self::$_instance;
+	}
+
+	/**
+	 * SST_TaxCloud_V3 constructor.
+	 */
+	protected function __construct() {
+		add_action( 'sst_update_data_mover_settings', array( 'SST_TaxCloud_V3_API', 'update_data_mover_settings' ) );
+		add_filter( 'sst_get_option', array( $this, 'sst_update_realtime_calc_option' ), 10, 2 );
+		add_filter( 'sst_settings_form_fields', array( $this, 'disable_real_time_calc_option' ) );
+	}
+
+	/**
+	 * Disable the disable_real_time_calc option if data mover is true.
+	 *
+	 * @param array $fields Array of settings fields.
+	 *
+	 * @return array
+	 */
+	function disable_real_time_calc_option( $fields ) {
+		$data_mover = SST_Settings::get( 'data_mover', false );
+		if( $data_mover ) {
+			$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+			$fields['disable_real_time_calc']['options'] = array(
+				'yes' => __( 'Yes', 'simple-sales-tax' ),
+			);
+		}
+		return $fields;
+	}
+
+
+	/**
+	 * Update the disable_real_time_calc option if data mover is true.
+	 *
+	 * @param string $value Value of the option.
+	 * @param string $key   Key of the option.
 	 *
 	 * @return string
 	 */
-	private static function get_auth_url() {
-		// For now, we'll default to PROD unless a constant is defined for staging.
-		// In the future, this could be a setting.
-		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
-			return self::STAGING_AUTH_URL;
+	function sst_update_realtime_calc_option( $value, $key ) {
+		if( 'disable_real_time_calc' === $key ) {
+			$data_mover = SST_Settings::get( 'data_mover', false );
+			if( $data_mover ) {
+				return 'yes';
+			}
 		}
-		return self::PROD_AUTH_URL;
+		return $value;
 	}
 
-	/**
-	 * Get the appropriate Management URL based on environment.
-	 *
-	 * @return string
-	 */
-	private static function get_mgmt_url() {
-		if ( defined( 'SST_TAXCLOUD_STAGING' ) && SST_TAXCLOUD_STAGING ) {
-			return self::STAGING_MGMT_URL;
-		}
-		return self::PROD_MGMT_URL;
-	}
-
-	/**
-	 * Exchange v1 credentials for v3 Bearer token.
-	 *
-	 * @param string $api_login_id TaxCloud API Login ID.
-	 * @param string $api_key      TaxCloud API Key.
-	 * @return string|WP_Error Access token on success, WP_Error on failure.
-	 */
-	public static function get_auth_token( $api_login_id, $api_key ) {
-		$url = self::get_auth_url();
-
-		$response = wp_remote_post( $url, array(
-			'headers' => array(
-				'Content-Type' => 'application/json',
-			),
-			'body'    => json_encode( array(
-				'apiLoginID' => $api_login_id,
-				'apiKey'     => $api_key,
-			) ),
-			'timeout' => 30,
-		) );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
-		if ( $code >= 400 ) {
-			return new WP_Error( 'sst_v3_auth_error', 'Failed to authenticate with TaxCloud v3 API: ' . ( isset( $data['message'] ) ? $data['message'] : $body ) );
-		}
-
-		if ( empty( $data['access_token'] ) ) {
-			return new WP_Error( 'sst_v3_auth_error', 'No access token received from TaxCloud v3 API.' );
-		}
-
-		return $data['access_token'];
-	}
-
-	/**
-	 * Get connection settings using Bearer token.
-	 *
-	 * @param string $api_key      TaxCloud API Key (used as connection ID).
-	 * @param string $access_token Bearer token.
-	 * @return array|WP_Error Settings array on success, WP_Error on failure.
-	 */
-	public static function get_connection_settings( $api_key, $access_token ) {
-		$url = self::get_mgmt_url() . '/connections/' . $api_key;
-
-		$response = wp_remote_get( $url, array(
-			'headers' => array(
-				'Authorization' => 'Bearer ' . $access_token,
-				'Content-Type'  => 'application/json',
-			),
-			'timeout' => 30,
-		) );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-
-		if ( $code === 404 ) {
-			// Connection settings don't exist yet, which is normal for new connections.
-			// Return empty settings.
-			return array();
-		}
-
-		if ( $code >= 400 ) {
-			return new WP_Error( 'sst_v3_settings_error', 'Failed to retrieve connection settings: ' . $body );
-		}
-
-		return json_decode( $body, true );
-	}
-
-	/**
-	 * Get settings using v1 credentials.
-	 *
-	 * @param string $api_login_id TaxCloud API Login ID.
-	 * @param string $api_key      TaxCloud API Key.
-	 * @return array|WP_Error Settings array on success, WP_Error on failure.
-	 */
-	public static function get_settings_with_v1_creds( $api_login_id, $api_key ) {
-		$token = self::get_auth_token( $api_login_id, $api_key );
-
-		if ( is_wp_error( $token ) ) {
-			return $token;
-		}
-
-		return self::get_connection_settings( $api_key, $token );
-	}
-
-	/**
-	 * Update data mover settings using v1 credentials.
-	 *
-	 * @param string $api_login_id TaxCloud API Login ID.
-	 * @param string $api_key      TaxCloud API Key.
-	 * @return array|WP_Error Settings array on success, WP_Error on failure.
-	 */
-	public static function update_data_mover_settings( $api_login_id = null, $api_key = null ) {
-		if ( ! $api_login_id || ! $api_key ) {
-			$api_login_id	= SST_Settings::get( 'tc_id' );
-			$api_key			= SST_Settings::get( 'tc_key' );
-		}
-
-		// Return if empty
-		if ( empty( $api_login_id ) || empty( $api_key ) ) {
-			SST_Logger::add( 'Failed to update data mover settings: API Login ID or API Key is empty' );
-			return;
-		}
-
-		// Add to cronjob to check daily
-		if ( ! wp_next_scheduled( 'sst_update_data_mover_settings' ) ) {
-			wp_schedule_event( time(), 'daily', 'sst_update_data_mover_settings' );
-		}
-
-		// Check v3 settings
-		$v3_settings = self::get_settings_with_v1_creds( $api_login_id, $api_key );
-
-		if ( ! is_wp_error( $v3_settings ) ) {
-			$data_mover = (bool) isset( $v3_settings['options']['data_mover']['flag'] ) && $v3_settings['options']['data_mover']['flag'];
-			SST_Settings::set( 'data_mover', $data_mover );
-		} else {
-			// Log error but don't fail verification if v3 fails (optional, depending on strictness)
-			SST_Logger::add( 'Failed to fetch v3 settings: ' . $v3_settings->get_error_message() );
-		}
-	}
 }
+
+// Initialize the instance.
+SST_TaxCloud_V3::instance();

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -586,20 +586,20 @@ function sst_update_realtime_calc_option( $value, $key ) {
 }
 add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
 
-/**
- * Disable the disable_real_time_calc option if data mover is true.
- */
-function disable_real_time_calc_option( $fields ) {
-	$data_mover = SST_Settings::get( 'data_mover', false );
-	if( $data_mover ) {
-		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
-		$fields['disable_real_time_calc']['options'] = array(
-			'yes' => __( 'Yes', 'simple-sales-tax' ),
-		);
-	}
-	return $fields;
-}
-add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
+// /**
+//  * Disable the disable_real_time_calc option if data mover is true.
+//  */
+// function disable_real_time_calc_option( $fields ) {
+// 	$data_mover = SST_Settings::get( 'data_mover', false );
+// 	if( $data_mover ) {
+// 		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+// 		$fields['disable_real_time_calc']['options'] = array(
+// 			'yes' => __( 'Yes', 'simple-sales-tax' ),
+// 		);
+// 	}
+// 	return $fields;
+// }
+// add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
 
 /**
  * Update data mover settings.

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -592,7 +592,7 @@ add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
 function disable_real_time_calc_option( $fields ) {
 	$data_mover = SST_Settings::get( 'data_mover', false );
 	if( $data_mover ) {
-		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+		// $fields['disable_real_time_calc']['disabled'] =  $data_mover;
 		// $fields['disable_real_time_calc']['options'] = array(
 		// 	'yes' => __( 'Yes', 'simple-sales-tax' ),
 		// );

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -571,3 +571,32 @@ function sst_get_rate_label() {
 function sst_get_rate_code() {
 	return apply_filters( 'wootax_rate_code', 'SALES-TAX' );
 }
+
+/**
+ * Update the disable_real_time_calc option if data mover is true.
+ */
+function sst_update_realtime_calc_option( $value, $key ) {
+	if( 'disable_real_time_calc' === $key ) {
+		$data_mover = SST_Settings::get( 'data_mover', false );
+		if( $data_mover ) {
+			return 'yes';
+		}
+	}
+	return $value;
+}
+add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
+
+/**
+ * Disable the disable_real_time_calc option if data mover is true.
+ */
+function disable_real_time_calc_option( $fields ) {
+	$data_mover = SST_Settings::get( 'data_mover', false );
+	if( $data_mover ) {
+		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+		$fields['disable_real_time_calc']['options'] = array(
+			'yes' => __( 'Yes', 'simple-sales-tax' ),
+		);
+	}
+	return $fields;
+}
+add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -590,13 +590,13 @@ add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
  * Disable the disable_real_time_calc option if data mover is true.
  */
 function disable_real_time_calc_option( $fields ) {
-	// $data_mover = SST_Settings::get( 'data_mover', false );
-	// if( $data_mover ) {
-	// 	// $fields['disable_real_time_calc']['disabled'] =  $data_mover;
-	// 	// $fields['disable_real_time_calc']['options'] = array(
-	// 	// 	'yes' => __( 'Yes', 'simple-sales-tax' ),
-	// 	// );
-	// }
+	$data_mover = true;
+	if( $data_mover ) {
+		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+		$fields['disable_real_time_calc']['options'] = array(
+			'yes' => __( 'Yes', 'simple-sales-tax' ),
+		);
+	}
 	return $fields;
 }
 add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option', 15 );

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -571,37 +571,3 @@ function sst_get_rate_label() {
 function sst_get_rate_code() {
 	return apply_filters( 'wootax_rate_code', 'SALES-TAX' );
 }
-
-/**
- * Update the disable_real_time_calc option if data mover is true.
- */
-function sst_update_realtime_calc_option( $value, $key ) {
-	if( 'disable_real_time_calc' === $key ) {
-		$data_mover = SST_Settings::get( 'data_mover', false );
-		if( $data_mover ) {
-			return 'yes';
-		}
-	}
-	return $value;
-}
-add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
-
-/**
- * Disable the disable_real_time_calc option if data mover is true.
- */
-function disable_real_time_calc_option( $fields ) {
-	$data_mover = true;
-	if( $data_mover ) {
-		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
-		$fields['disable_real_time_calc']['options'] = array(
-			'yes' => __( 'Yes', 'simple-sales-tax' ),
-		);
-	}
-	return $fields;
-}
-add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option', 15 );
-
-/**
- * Update data mover settings.
- */
-add_action( 'sst_update_data_mover_settings', array( 'SST_TaxCloud_V3', 'update_data_mover_settings' ) );

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -586,20 +586,20 @@ function sst_update_realtime_calc_option( $value, $key ) {
 }
 add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
 
-// /**
-//  * Disable the disable_real_time_calc option if data mover is true.
-//  */
-// function disable_real_time_calc_option( $fields ) {
-// 	$data_mover = SST_Settings::get( 'data_mover', false );
-// 	if( $data_mover ) {
-// 		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
-// 		$fields['disable_real_time_calc']['options'] = array(
-// 			'yes' => __( 'Yes', 'simple-sales-tax' ),
-// 		);
-// 	}
-// 	return $fields;
-// }
-// add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
+/**
+ * Disable the disable_real_time_calc option if data mover is true.
+ */
+function disable_real_time_calc_option( $fields ) {
+	$data_mover = SST_Settings::get( 'data_mover', false );
+	if( $data_mover ) {
+		$fields['disable_real_time_calc']['disabled'] =  $data_mover;
+		// $fields['disable_real_time_calc']['options'] = array(
+		// 	'yes' => __( 'Yes', 'simple-sales-tax' ),
+		// );
+	}
+	return $fields;
+}
+add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
 
 /**
  * Update data mover settings.

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -590,16 +590,16 @@ add_filter( 'sst_get_option', 'sst_update_realtime_calc_option', 10, 2 );
  * Disable the disable_real_time_calc option if data mover is true.
  */
 function disable_real_time_calc_option( $fields ) {
-	$data_mover = SST_Settings::get( 'data_mover', false );
-	if( $data_mover ) {
-		// $fields['disable_real_time_calc']['disabled'] =  $data_mover;
-		// $fields['disable_real_time_calc']['options'] = array(
-		// 	'yes' => __( 'Yes', 'simple-sales-tax' ),
-		// );
-	}
+	// $data_mover = SST_Settings::get( 'data_mover', false );
+	// if( $data_mover ) {
+	// 	// $fields['disable_real_time_calc']['disabled'] =  $data_mover;
+	// 	// $fields['disable_real_time_calc']['options'] = array(
+	// 	// 	'yes' => __( 'Yes', 'simple-sales-tax' ),
+	// 	// );
+	// }
 	return $fields;
 }
-add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
+add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option', 15 );
 
 /**
  * Update data mover settings.

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -600,3 +600,8 @@ function disable_real_time_calc_option( $fields ) {
 	return $fields;
 }
 add_filter( 'sst_settings_form_fields', 'disable_real_time_calc_option' );
+
+/**
+ * Update data mover settings.
+ */
+add_action( 'sst_update_data_mover_settings', array( 'SST_TaxCloud_V3', 'update_data_mover_settings' ) );

--- a/v3.md
+++ b/v3.md
@@ -64,7 +64,7 @@ curl -X GET \
   "id": "fb3e8a3a-057b-4628-a743-c89b4e37dfa8",
   "name": "asdasd1",
   "options": {
-    "woo_data_mover": {
+    "data_mover": {
       "type": "flag",
       "flag": true
     }
@@ -164,9 +164,9 @@ if ($settings) {
 
 ## Connection Settings Structure
 
-The `woo_data_mover` flag determines the integration mode:
-- `flag: true` = Premium mode (data mover enabled)
-- `flag: false` = Basic mode (data mover disabled)
+The `data_mover` flag determines the integration mode:
+- `flag: false` = Premium mode (data mover enabled)
+- `flag: true` = Basic mode (data mover disabled)
 
 ## Error Handling
 

--- a/v3.md
+++ b/v3.md
@@ -1,0 +1,182 @@
+# WooCommerce Connection Settings - Using v1 Tokens
+
+Simple guide for accessing WooCommerce connection settings using only your v1 API credentials (no Auth0 required).
+
+## Overview
+
+This integration uses a two-step process:
+1. Exchange your v1 API credentials for a v3 Bearer token
+2. Use the Bearer token to access connection settings
+
+## Prerequisites
+
+- Your TaxCloud v1 API credentials:
+  - `apiLoginID` (e.g., `FE95570`)
+  - `apiKey` (UUID format, e.g., `fb3e8a3a-057b-4628-a743-c89b4e37dfa8`)
+
+## Step 1: Get v3 Bearer Token
+
+Exchange your v1 credentials for a v3 Bearer token:
+
+**Endpoint:** `POST /api/v3/auth/token`
+
+**Request:**
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "apiLoginID": "FE95570",
+    "apiKey": "fb3e8a3a-057b-4628-a743-c89b4e37dfa8"
+  }' \
+  https://staging-taxcloudapi.azurewebsites.net/api/v3/auth/token
+```
+
+**Response:**
+```json
+{
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "access_token_validTo": "2025-11-26T00:52:55Z",
+  "token_type": "Bearer",
+  "scope": "v3_api",
+  "merchant_id": 4,
+  "contact_id": 11315,
+  "connection_id": "59662"
+}
+```
+
+## Step 2: Get Connection Settings
+
+Use the Bearer token to access connection settings:
+
+**Endpoint:** `GET /mgmt/connections/{apiKey}`
+
+**Request:**
+```bash
+curl -X GET \
+  -H "Authorization: Bearer {access_token}" \
+  -H "Content-Type: application/json" \
+  https://api.v3.taxcloud.net/mgmt/connections/fb3e8a3a-057b-4628-a743-c89b4e37dfa8
+```
+
+**Response:**
+```json
+{
+  "id": "fb3e8a3a-057b-4628-a743-c89b4e37dfa8",
+  "name": "asdasd1",
+  "options": {
+    "woo_data_mover": {
+      "type": "flag",
+      "flag": true
+    }
+  }
+}
+```
+
+## PHP Example
+
+```php
+function get_woo_connection_settings_v1($apiLoginID, $apiKey, $environment = 'staging') {
+    // Environment URLs
+    $baseUrls = [
+        'staging' => 'https://staging-taxcloudapi.azurewebsites.net',
+        'prod' => 'https://taxcloudapi.azurewebsites.net'
+    ];
+    
+    $v3MgmtUrls = [
+        'staging' => 'https://api.v3.taxcloud.net/mgmt',
+        'prod' => 'https://api.v3.taxcloud.com/mgmt'
+    ];
+    
+    $baseUrl = $baseUrls[$environment] ?? $baseUrls['staging'];
+    $mgmtUrl = $v3MgmtUrls[$environment] ?? $v3MgmtUrls['staging'];
+    
+    // Step 1: Get Bearer token
+    $tokenUrl = $baseUrl . '/api/v3/auth/token';
+    $tokenData = [
+        'apiLoginID' => $apiLoginID,
+        'apiKey' => $apiKey
+    ];
+    
+    $tokenResponse = wp_remote_post($tokenUrl, [
+        'headers' => ['Content-Type' => 'application/json'],
+        'body' => json_encode($tokenData),
+        'timeout' => 30
+    ]);
+    
+    if (is_wp_error($tokenResponse)) {
+        error_log('Token request failed: ' . $tokenResponse->get_error_message());
+        return null;
+    }
+    
+    $tokenBody = json_decode(wp_remote_retrieve_body($tokenResponse), true);
+    $accessToken = $tokenBody['access_token'] ?? null;
+    
+    if (!$accessToken) {
+        error_log('Failed to get access token: ' . wp_remote_retrieve_body($tokenResponse));
+        return null;
+    }
+    
+    // Step 2: Get connection settings
+    $settingsUrl = $mgmtUrl . '/connections/' . $apiKey;
+    $settingsResponse = wp_remote_get($settingsUrl, [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $accessToken,
+            'Content-Type' => 'application/json'
+        ],
+        'timeout' => 30
+    ]);
+    
+    if (is_wp_error($settingsResponse)) {
+        error_log('Settings request failed: ' . $settingsResponse->get_error_message());
+        return null;
+    }
+    
+    $httpCode = wp_remote_retrieve_response_code($settingsResponse);
+    if ($httpCode === 404) {
+        // Connection settings don't exist yet (normal for new connections)
+        return null;
+    }
+    
+    if ($httpCode < 200 || $httpCode >= 300) {
+        error_log('Settings request failed with HTTP ' . $httpCode . ': ' . wp_remote_retrieve_body($settingsResponse));
+        return null;
+    }
+    
+    return json_decode(wp_remote_retrieve_body($settingsResponse), true);
+}
+
+// Usage
+$settings = get_woo_connection_settings_v1('FE95570', 'fb3e8a3a-057b-4628-a743-c89b4e37dfa8', 'staging');
+
+if ($settings) {
+    $wooDataMover = $settings['options']['woo_data_mover']['flag'] ?? false;
+    $mode = $wooDataMover ? 'premium' : 'basic';
+    echo "Current mode: " . $mode;
+} else {
+    echo "Connection settings not found or error occurred";
+}
+```
+
+## Environments
+
+- **staging**: `https://staging-taxcloudapi.azurewebsites.net` (default)
+- **prod**: `https://taxcloudapi.azurewebsites.net`
+
+## Connection Settings Structure
+
+The `woo_data_mover` flag determines the integration mode:
+- `flag: true` = Premium mode (data mover enabled)
+- `flag: false` = Basic mode (data mover disabled)
+
+## Error Handling
+
+- **400 Bad Request**: Invalid v1 credentials
+- **404 Not Found**: Connection settings don't exist yet (normal for new connections)
+- **401 Unauthorized**: Bearer token expired or invalid (get a new token)
+- **422 Unprocessable Entity**: Invalid connection ID format (must be UUID)
+
+## Notes
+
+- Bearer tokens expire (check `access_token_validTo` in the token response)
+- The `apiKey` is used as the `connection_id` in the v3 API
+- Connection settings may not exist for new connections (404 is normal)


### PR DESCRIPTION
https://taxcloud.atlassian.net/browse/DEV-5366

<img width="1104" height="301" alt="image" src="https://github.com/user-attachments/assets/386d0490-b135-4f69-8c57-4f32797a54bb" />

<img width="745" height="149" alt="image" src="https://github.com/user-attachments/assets/aeb092c5-ea7b-48ce-8fbb-e275528fdbc6" />


- [x] Existing users will default to premium

- [x] Until we reach taxcloud API, default to premium

- [x] Store our premium status/config when we hit the connection API

- [x] Display the current mode in integration settings

- [x] This should be read only

- [x] Add a refresh button to check TaxCloud for the current mode setting

- [x] Add a “Configure in TaxCloud” link that points to the specific integration settings for this Woo connection

- [ ] Modes are “Data Import” and “Real Time” (see screenshot for how we’re presenting in the TxC web app)