### PR TITLE
Bump version to 8.4.0

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,7 +1,5 @@
 /**
  * TaxCloud for WooCommerce - admin CSS 
- *
- * @version 8.3.8
  */
 .toplevel .form-error {
     border-color: #be0636 !important;

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,20 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- [8.4.0] - 2025-12-04 =
+
+Changed:
+- WordPress Tested up to: 6.9
+- WC tested up to: 10.3.5
+
+Added:
+- DEV-5366: Force "disable real time calc" for non-premium users in woo plugin 
+- Introduce data_mover v3 APIs
+
+Fixed:
+- DEV-6306: Investigate vulnerability report from Patchstack
+
+
 - [8.3.8] - 2025-11-20 =
 
 Added:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.3.8';
+	    public $version = '8.4.0';
 
 	/**
 	 * The singleton plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.3.8",
+  "version": "8.4.0",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
-Tested up to: 6.8.3
-Stable tag: 8.3.8
+Tested up to: 6.9
+Stable tag: 8.4.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,15 +7,15 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.3.8
+ * Version:              8.4.0
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later
  *
  * Requires at least:    4.5.0
- * Tested up to:         6.8.0
+ * Tested up to:         6.9
  * WC requires at least: 6.9.0
- * WC tested up to:      10.2.1
+ * WC tested up to:      10.3.5
  * Requires PHP:         7.4
  *
  * @category             Plugin


### PR DESCRIPTION
Changed:
- WordPress Tested up to: 6.9
- WC tested up to: 10.3.5

Added:
- DEV-5366: Force "disable real time calc" for non-premium users in woo plugin 
- Introduce data_mover v3 APIs

Fixed:
- DEV-6306: Investigate vulnerability report from Patchstack
