### PR TITLE
  DEV-6508 - Adjust Integration Mode display to match terminology in the TaxCloud

### DIFF
--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -426,7 +426,7 @@ class SST_Integration extends WC_Integration {
 		$api_key          = SST_Settings::get( 'tc_key' );
 		$data_mover       = SST_Settings::get( 'data_mover', false );
 
-		$integration_mode = $data_mover == false ? __( 'Premium', 'simple-sales-tax' ) : __( 'Basic', 'simple-sales-tax' );
+		$integration_mode = $data_mover == false ? __( 'Real Time', 'simple-sales-tax' ) : __( 'Data Import', 'simple-sales-tax' );
 
 		ob_start();
 		?>
@@ -459,14 +459,6 @@ class SST_Integration extends WC_Integration {
 						</div>
 						<div class="description">
 							<p>
-								<?php
-								echo wp_kses_post(
-									__(
-										'Premium users can calculate tax in real-time while Basic users can only do data import to TaxCloud.',
-										'simple-sales-tax'
-									)
-								);
-								?>
 								<a href="https://app.taxcloud.com/go/integrations" target="_blank">
 									<?php echo wp_kses_post( __( 'Configure in TaxCloud', 'simple-sales-tax' ) ); ?>
 								</a>

--- a/includes/class-sst-ajax.php
+++ b/includes/class-sst-ajax.php
@@ -371,7 +371,7 @@ class SST_Ajax {
 
 		// Get data mover settings
 		$data_mover = SST_Settings::get( 'data_mover', false );
-		$integration_mode = $data_mover == false ? __( 'Premium', 'simple-sales-tax' ) : __( 'Basic', 'simple-sales-tax' );
+		$integration_mode = $data_mover == false ? __( 'Real Time', 'simple-sales-tax' ) : __( 'Data Import', 'simple-sales-tax' );
 
 		// Response
 		wp_send_json_success( [ 'integration_mode' => $integration_mode, 'data_mover' => $data_mover ] );


### PR DESCRIPTION
https://taxcloud.atlassian.net/browse/DEV-6508

- Basic mode is renamed “Data Import”
- Premium mode is renamed “Real Time”
- The descriptive text below the Integration Mode field is removed, leaving only the “Configure in TaxCloud” link.