### PR TITLE
DEV-6506 - Make sure native tax features aren't blocked in Data Import mode

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -23,24 +23,6 @@ a.delete_refund {
     max-width: 771px;
 }
 
-/**
- * Hide Tax Status/Tax Class fields
- */
-.form-field._tax_status_field,
-.form-field._tax_class_field {
-    display: none !important;
-}
-
-#woocommerce-fields-bulk>label:nth-of-type(2),
-#woocommerce-fields-bulk>label:nth-of-type(3) {
-    display: none !important;
-}
-
-.woocommerce_variable_attributes .data>div:nth-of-type(5) p:nth-of-type(2),
-p[class*="variable_tax_class"] {
-    display: none !important;
-}
-
 
 /**
  * Shipping origin select


### PR DESCRIPTION
Remove CSS rules that hid tax status and tax class fields.

<img width="752" height="200" alt="image" src="https://github.com/user-attachments/assets/fabc90bf-117d-4dab-911f-6822f83b93a3" />
