### PR TITLE
Bump version to 8.4.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,17 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- [8.4.1] - 2025-12-04 =
+- [8.4.1] - 2026-01-07 =
 
+Changed:
+- Bump tested WC version to 10.4.3
+
+Fixed:
+- DEV-6508 - Adjust Integration Mode display to match terminology in the TaxCloud 
+- DEV-6506 - Make sure native tax features aren't blocked in Data Import mode 
+
+Added:
+- DEV-6506 - Woo Tax plugin functions when the integration is in Data Import mode 
 
 - [8.4.0] - 2025-12-04 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- [8.4.1] - 2025-12-04 =
+
+
 - [8.4.0] - 2025-12-04 =
 
 Changed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.4.0';
+	    public $version = '8.4.1';
 
 	/**
 	 * The singleton plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.9
-Stable tag: 8.4.0
+Stable tag: 8.4.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -15,7 +15,7 @@
  * Requires at least:    4.5.0
  * Tested up to:         6.9
  * WC requires at least: 6.9.0
- * WC tested up to:      10.4.2
+ * WC tested up to:      10.4.3
  * Requires PHP:         7.4
  *
  * @category             Plugin

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.4.0
+ * Version:              8.4.1
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later
@@ -15,7 +15,7 @@
  * Requires at least:    4.5.0
  * Tested up to:         6.9
  * WC requires at least: 6.9.0
- * WC tested up to:      10.3.5
+ * WC tested up to:      10.4.2
  * Requires PHP:         7.4
  *
  * @category             Plugin


### PR DESCRIPTION
Changed:
- Bump tested WC version to 10.4.3

Fixed:
- DEV-6508 - Adjust Integration Mode display to match terminology in the TaxCloud 
- DEV-6506 - Make sure native tax features aren't blocked in Data Import mode 

Added:
- DEV-6506 - Woo Tax plugin functions when the integration is in Data Import mode 