### PR TITLE
Bump version to 8.4.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,16 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- [8.4.5] - 2026-02-20 =
+
+Fixed:
+- [DEV-5969] - Completed WooCommerce orders not being captured in TaxCloud
+
+Fixed:
+- [DEV-6070] - Handle Colorado excise tax on guns and ammo from WooCommerce
+- [DEV-6422] - Tax exempt customer issues in WooCommerce
+
+
 - [8.4.4] - 2026-02-03 =
 
 Fixed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.4.4';
+	    public $version = '8.4.5';
 
 	/**
 	 * The singleton plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.4.4",
+  "version": "8.4.5",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
-Tested up to: 6.9
-Stable tag: 8.4.4
+Tested up to: 6.9.1
+Stable tag: 8.4.5
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -13,9 +13,9 @@
  * License:              GPLv2 or later
  *
  * Requires at least:    4.5.0
- * Tested up to:         6.9
+ * Tested up to:         6.9.1
  * WC requires at least: 6.9.0
- * WC tested up to:      10.4.3
+ * WC tested up to:      10.5.2
  * Requires PHP:         7.4
  *
  * @category             Plugin


### PR DESCRIPTION
Fixed:
- [DEV-5969] - Completed WooCommerce orders not being captured in TaxCloud

[DEV-5969]: https://taxcloud.atlassian.net/browse/DEV-5969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ