### PR TITLE
[DEV-7056] - Move tax location script not working

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -7,6 +7,7 @@ node_modules
 releases
 docker
 includes/vendor/woocommerce
+scripts
 
 # Files
 .distignore
@@ -18,3 +19,4 @@ cypress.config.js
 gruntfile.js
 package-lock.json
 package.json
+v3.md

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -1,0 +1,117 @@
+# WooCommerce Custom Scripts
+
+This directory contains standalone WooCommerce customization scripts maintained separately from the core theme and plugin files.
+
+These scripts are intended to be installed manually and are not auto-loaded by the repository.
+
+---
+
+# Installation Instructions
+
+## Recommended Method: Install as a Custom Plugin
+
+This approach ensures the customization remains update-safe and isolated from theme changes.
+
+### Step 1 — Create a New Plugin File
+
+Navigate to:
+
+```
+/wp-content/plugins/
+```
+
+Create a new file, for example:
+
+```
+custom-sst-overrides.php
+```
+
+---
+
+### Step 2 — Add Plugin Header
+
+At the top of the file, add:
+
+```php
+<?php
+/**
+ * Plugin Name: Custom SST Overrides
+ * Description: Custom WooCommerce modifications related to SST integration.
+ * Version: 1.0
+ */
+```
+
+---
+
+### Step 3 — Copy Script Contents
+
+Open the required script from this `/scripts/` directory (e.g. `sst-tax-exemption-form-reposition.php`) and paste its contents below the plugin header.
+
+---
+
+### Step 4 — Activate the Plugin
+
+Go to:
+
+```
+WordPress Admin → Plugins
+```
+
+Locate **Custom SST Overrides** and click **Activate**.
+
+---
+
+# Alternative Method (If Using a Child Theme)
+
+If preferred, the script may be added to:
+
+```
+/wp-content/themes/your-child-theme/functions.php
+```
+
+⚠️ Do not install in a parent theme, as updates will overwrite changes.
+
+---
+
+# Included Script
+
+## `sst-tax-exemption-form-reposition.php`
+
+### Purpose
+
+Repositions the SST Tax Exemption form so that it appears **after the Billing Details section** on the WooCommerce checkout page.
+
+### Technical Scope
+
+* Targets WooCommerce **classic (shortcode-based) checkout**
+* Does not modify block-based checkout
+* Removes the original hook:
+
+  ```
+  woocommerce_checkout_after_customer_details
+  ```
+* Re-attaches output to:
+
+  ```
+  woocommerce_after_checkout_billing_form
+  ```
+
+---
+
+# Compatibility Notes
+
+* Requires WooCommerce (classic checkout template)
+* Requires SST integration plugin to be active
+* Safe for production once tested in staging
+* Does not modify core WooCommerce files
+
+---
+
+# Deployment Recommendation
+
+We recommend:
+
+1. Deploying to staging first
+2. Verifying checkout behavior
+3. Confirming tax exemption flow works as expected
+4. Then promoting to production

--- a/scripts/sst-tax-exemption-form-reposition.php
+++ b/scripts/sst-tax-exemption-form-reposition.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Reposition the SST Tax Exemption Form.
+ *
+ * This script moves the SST Tax Exemption form from its default location
+ * (after customer details) to a custom location (after the billing form).
+ *
+ * This can be placed in a theme's functions.php or treated as a standalone plugin file.
+ */
+
+add_action( 'wp', function () {
+	global $wp_filter;
+
+	// Define the source and destination hooks for the form output.
+	$original_hook = 'woocommerce_checkout_after_customer_details';
+	$new_hook      = 'woocommerce_after_checkout_billing_form';
+
+	// If no filters are registered on the original hook, there's nothing for us to do.
+	if ( empty( $wp_filter[ $original_hook ] ) ) {
+		return;
+	}
+
+	/**
+	 * Iterate through all callbacks attached to the original hook to find
+	 * the specific 'output_exemption_form' method from the SST_Checkout class.
+	 */
+	foreach ( $wp_filter[ $original_hook ]->callbacks as $priority => $callbacks ) {
+
+		foreach ( $callbacks as $callback ) {
+
+			// Check if the callback is an array containing an instance of SST_Checkout.
+			if (
+				is_array( $callback['function'] ) &&
+				is_object( $callback['function'][0] ) &&
+				get_class( $callback['function'][0] ) === 'SST_Checkout'
+			) {
+
+				/** @var SST_Checkout $instance */
+				$instance = $callback['function'][0];
+
+				/**
+				 * 1. Remove the action from the original hook.
+				 * Use the same priority it was originally registered with.
+				 */
+				remove_action(
+					$original_hook,
+					array( $instance, 'output_exemption_form' ),
+					$priority
+				);
+
+				/**
+				 * 2. Add the action to the new desired hook.
+				 * We use a priority of 15 to place it appropriately within the billing form.
+				 */
+				add_action(
+					$new_hook,
+					array( $instance, 'output_exemption_form' ),
+					15
+				);
+
+				// Once we've found and moved the form, we can exit the loop.
+				return;
+			}
+		}
+	}
+
+}, 20 );


### PR DESCRIPTION
Reposition SST tax exemption form to appear after billing details on WooCommerce checkout, including installation instructions.