### PR TITLE
Bump version to 8.4.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,17 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- [8.4.6] - 2026-03-10 =
+
+Fixed:
+- [DEV-7056] - Move tax location script not working
+- [DEV-6760] - PropShopTrader OU (61602) | WooCommerce VAT Issue
+
+Added:
+- [DEV-6358] - Link directly to the correct TaxCloud connection in TaxCloud from the plugin
+- [DEV-6609] - Rename field to 'Disable Integration' for clarity (Option to disable the integration)
+
+
 - [8.4.5] - 2026-02-20 =
 
 Fixed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.4.5';
+	    public $version = '8.4.6';
 
 	/**
 	 * The singleton plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.4.5",
+  "version": "8.4.6",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.9.1
-Stable tag: 8.4.5
+Stable tag: 8.4.6
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.4.4
+ * Version:              8.4.6
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later
@@ -19,7 +19,7 @@
  * Requires PHP:         7.4
  *
  * @category             Plugin
- * @copyright            Copyright © 2024 The Federal Tax Authority, LLC
+ * @copyright            Copyright © 2026 The Federal Tax Authority, LLC
  * @author               Brett Porcelli
  * @license              GPL2
  *


### PR DESCRIPTION
Fixed:
- [DEV-7056] - Move tax location script not working
- [DEV-6760] - PropShopTrader OU (61602) | WooCommerce VAT Issue

Added:
- [DEV-6358] - Link directly to the correct TaxCloud connection in TaxCloud from the plugin
- [DEV-6609] - Rename field to 'Disable Integration' for clarity (Option to disable the integration)


[DEV-7056]: https://taxcloud.atlassian.net/browse/DEV-7056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-6760]: https://taxcloud.atlassian.net/browse/DEV-6760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-6358]: https://taxcloud.atlassian.net/browse/DEV-6358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-6609]: https://taxcloud.atlassian.net/browse/DEV-6609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ