### PR TITLE
Bump version to 8.4.7

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,10 @@ Fixed:
 - [DEV-7181] - Wild Horse Ammo (58285) - Seeing excise tax applied for exempt orders (WooCommerce)
 - [DEV-6819] - Exemption certificates should use the real customer ID from WooCommerce (v3 API)
 
+Changed:
+- WordPress Tested up to: 6.9.4
+- WC tested up to: 10.6.1
+
 
 - [8.4.6] - 2026-03-10 =
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,13 @@ Changelog for Simple Sales Tax
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- [8.4.7] - 2026-03-26 =
+
+Fixed:
+- [DEV-7181] - Wild Horse Ammo (58285) - Seeing excise tax applied for exempt orders (WooCommerce)
+- [DEV-6819] - Exemption certificates should use the real customer ID from WooCommerce (v3 API)
+
+
 - [8.4.6] - 2026-03-10 =
 
 Fixed:

--- a/includes/class-simplesalestax.php
+++ b/includes/class-simplesalestax.php
@@ -20,7 +20,7 @@ final class SimpleSalesTax {
 	 *
 	 * @var string
 	 */
-	    public $version = '8.4.6';
+	    public $version = '8.4.7';
 
 	/**
 	 * The singleton plugin instance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplesalestax",
-  "version": "8.4.6",
+  "version": "8.4.7",
   "description": "A TaxCloud integration for WooCommerce.",
   "scripts": {
     "build": "npm run build:blocks && npm run build:makepot && grunt",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
-Tested up to: 6.9.1
+Tested up to: 6.9.4
 Stable tag: 8.4.7
 Requires PHP: 7.4
 License: GPLv2 or later
@@ -80,7 +80,7 @@ Yes! TaxCloud for WooCommerce is fully compatible with the official WooCommerce 
 
 = What versions of WooCommerce and WordPress are supported? =
 
-TaxCloud for WooCommerce supports WooCommerce 7.0 to 8.9 and WordPress 6.0+.
+TaxCloud for WooCommerce supports WooCommerce 7.0 to 10.6.1 and WordPress 6.0+.
 
 = Can I assign different tax codes (TICs) to my products? = 
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fedtaxceo
 Tags: taxcloud, woocommerce, tax, sales tax, sales tax filing
 Requires at least: 4.5.0
 Tested up to: 6.9.1
-Stable tag: 8.4.6
+Stable tag: 8.4.7
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -7,7 +7,7 @@
  * Author:               TaxCloud
  * Author URI:           https://taxcloud.com
  * GitHub Plugin URI:    https://github.com/bporcelli/simplesalestax
- * Version:              8.4.6
+ * Version:              8.4.7
  * Text Domain:          simple-sales-tax
  * Domain Path:          /languages/
  * License:              GPLv2 or later

--- a/simple-sales-tax.php
+++ b/simple-sales-tax.php
@@ -13,9 +13,9 @@
  * License:              GPLv2 or later
  *
  * Requires at least:    4.5.0
- * Tested up to:         6.9.1
+ * Tested up to:         6.9.4
  * WC requires at least: 6.9.0
- * WC tested up to:      10.5.2
+ * WC tested up to:      10.6.1
  * Requires PHP:         7.4
  *
  * @category             Plugin


### PR DESCRIPTION
Fixed:
- [DEV-7181] - Wild Horse Ammo (58285) - Seeing excise tax applied for exempt orders (WooCommerce)
- [DEV-6819] - Exemption certificates should use the real customer ID from WooCommerce (v3 API)

Changed:
- WordPress Tested up to: 6.9.4
- WC tested up to: 10.6.1

[DEV-7181]: https://taxcloud.atlassian.net/browse/DEV-7181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-6819]: https://taxcloud.atlassian.net/browse/DEV-6819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ