### PR TITLE
[DEV-8511] - Hide checkout exemption form/options on Data Import mode

### DIFF
--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -34,6 +34,7 @@ class SST_Integration extends WC_Integration {
 		$this->init_form_fields();
 
 		// Register action hooks.
+		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'preserve_data_import_exemption_settings' ) );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'refresh_origin_address_list' ), 15 );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'update_data_mover_settings' ), 20 );
@@ -60,6 +61,35 @@ class SST_Integration extends WC_Integration {
 
 		$this->display_errors();
 		parent::admin_options();
+	}
+
+	/**
+	 * Preserve exemption settings while the fields are disabled in Data Import mode.
+	 *
+	 * @param array $settings Sanitized settings.
+	 *
+	 * @return array
+	 */
+	public function preserve_data_import_exemption_settings( $settings ) {
+		if ( empty( $settings['data_mover'] ) ) {
+			return $settings;
+		}
+
+		$current_settings = get_option( 'woocommerce_wootax_settings', array() );
+		$exemption_keys   = array(
+			'show_exempt',
+			'company_name',
+			'exempt_roles',
+			'restrict_exempt',
+		);
+
+		foreach ( $exemption_keys as $key ) {
+			if ( array_key_exists( $key, $current_settings ) ) {
+				$settings[ $key ] = $current_settings[ $key ];
+			}
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -34,7 +34,7 @@ class SST_Integration extends WC_Integration {
 		$this->init_form_fields();
 
 		// Register action hooks.
-		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'preserve_data_import_exemption_settings' ) );
+		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'preserve_data_import_disabled_settings' ) );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'refresh_origin_address_list' ), 15 );
 		add_action( 'woocommerce_update_options_integration_' . $this->id, array( $this, 'update_data_mover_settings' ), 20 );
@@ -64,26 +64,32 @@ class SST_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Preserve exemption settings while the fields are disabled in Data Import mode.
+	 * Preserve settings while their fields are disabled in Data Import mode.
 	 *
 	 * @param array $settings Sanitized settings.
 	 *
 	 * @return array
 	 */
-	public function preserve_data_import_exemption_settings( $settings ) {
+	public function preserve_data_import_disabled_settings( $settings ) {
 		if ( empty( $settings['data_mover'] ) ) {
 			return $settings;
 		}
 
 		$current_settings = get_option( 'woocommerce_wootax_settings', array() );
-		$exemption_keys   = array(
+		$disabled_keys    = array(
 			'show_exempt',
 			'company_name',
 			'exempt_roles',
 			'restrict_exempt',
+			'force_tax_lookup',
+			'enable_taxcloud_rate_limit',
+			'taxcloud_rate_limit_requests',
+			'taxcloud_rate_limit_scope',
+			'taxcloud_rate_limit_window',
+			'show_rate_limit_notice',
 		);
 
-		foreach ( $exemption_keys as $key ) {
+		foreach ( $disabled_keys as $key ) {
 			if ( array_key_exists( $key, $current_settings ) ) {
 				$settings[ $key ] = $current_settings[ $key ];
 			}

--- a/includes/class-sst-blocks-integration.php
+++ b/includes/class-sst-blocks-integration.php
@@ -59,6 +59,16 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * @return array
 	 */
 	public function get_script_data() {
+		if ( ! sst_should_show_tax_exemption_form() ) {
+			return array(
+				'showExemptionForm'    => false,
+				'certificateOptions'   => array(),
+				'selectedCertificate'  => '',
+				'isUserLoggedIn'       => is_user_logged_in(),
+				'myAccountEndpointUrl' => '',
+			);
+		}
+
 		$certificates = SST_Certificates::get_certificates_formatted();
 		$options      = array(
 			'new'  => 'Add new certificate',
@@ -217,6 +227,10 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * Force exemption block into checkout page markup after payment block.
 	 */
 	public function force_exemption_block( $content ) {
+		if ( ! sst_should_show_tax_exemption_form() ) {
+			return $content;
+		}
+
 		if ( ! has_block( 'woocommerce/checkout' ) ) {
 			return $content;
 		}

--- a/includes/class-sst-blocks.php
+++ b/includes/class-sst-blocks.php
@@ -91,6 +91,11 @@ class SST_Blocks {
 	 * @param array $data Data payload from `extensionCartUpdate`
 	 */
 	public function handle_cart_update( $data ) {
+		if ( ! sst_should_show_tax_exemption_form() ) {
+			WC()->session->set( 'sst_certificate_id', '' );
+			return;
+		}
+
 		$action = $data['action'] ?? '';
 
 		switch ( $action ) {

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -95,15 +95,23 @@ class SST_Settings {
 			self::is_using_cart_block() ||
 			self::is_using_checkout_block()
 		);
-		$disable_exemption_settings = self::is_data_mover_mode();
-		$exemption_description      = __(
+		$disable_data_import_settings = self::is_data_mover_mode();
+		$exemption_description        = __(
 			'If you have tax exempt customers, be sure to enable tax exemptions and enter your company name.',
 			'simple-sales-tax'
 		);
+		$rate_limit_description       = __(
+			'Configure rate limiting for TaxCloud tax lookup requests to prevent excessive API calls.',
+			'simple-sales-tax'
+		);
 
-		if ( $disable_exemption_settings ) {
+		if ( $disable_data_import_settings ) {
 			$exemption_description .= '<br><strong>' . __(
 				'Tax exemptions are not supported in Data Import mode. These settings are disabled until Integration Mode is switched back to Real Time.',
+				'simple-sales-tax'
+			) . '</strong>';
+			$rate_limit_description .= '<br><strong>' . __(
+				'Real-time TaxCloud lookup requests are not made in Data Import mode. These settings are disabled until Integration Mode is switched back to Real Time.',
 				'simple-sales-tax'
 			) . '</strong>';
 		}
@@ -209,7 +217,7 @@ class SST_Settings {
 				'default'     => 'false',
 				'description' => __( 'Set this to "Yes" if you have tax exempt customers.', 'simple-sales-tax' ),
 				'desc_tip'    => true,
-				'disabled'    => $disable_exemption_settings,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'company_name'                => array(
 				'title'       => __( 'Company Name', 'simple-sales-tax' ),
@@ -220,7 +228,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
-				'disabled'    => $disable_exemption_settings,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'exempt_roles'                => array(
 				'title'       => __( 'Exempt User Roles', 'simple-sales-tax' ),
@@ -233,7 +241,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
-				'disabled'    => $disable_exemption_settings,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'restrict_exempt'             => array(
 				'title'       => __( 'Restrict to Exempt Roles', 'simple-sales-tax' ),
@@ -248,7 +256,7 @@ class SST_Settings {
 					'yes' => __( 'Yes', 'simple-sales-tax' ),
 					'no'  => __( 'No', 'simple-sales-tax' ),
 				),
-				'disabled'    => $disable_exemption_settings,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'display_settings'            => array(
 				'title'       => __( 'Display Settings', 'simple-sales-tax' ),
@@ -349,6 +357,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'capture_orders_in_taxcloud'         => array(
 				'title'       => __( 'Capture Orders in TaxCloud', 'simple-sales-tax' ),
@@ -403,10 +412,7 @@ class SST_Settings {
 			'rate_limit_settings'         => array(
 				'title'       => __( 'Rate Limit Settings', 'simple-sales-tax' ),
 				'type'        => 'title',
-				'description' => __(
-					'Configure rate limiting for TaxCloud tax lookup requests to prevent excessive API calls.',
-					'simple-sales-tax'
-				),
+				'description' => $rate_limit_description,
 			),
 			'enable_taxcloud_rate_limit'  => array(
 				'title'       => __( 'Enable TaxCloud Rate Limiting', 'simple-sales-tax' ),
@@ -418,6 +424,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => false,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'taxcloud_rate_limit_requests' => array(
 				'title'       => __( 'Number of Requests', 'simple-sales-tax' ),
@@ -431,6 +438,7 @@ class SST_Settings {
 				'custom_attributes' => array(
 					'min' => 1,
 				),
+				'disabled'    => $disable_data_import_settings,
 			),
 			'taxcloud_rate_limit_scope'   => array(
 				'title'       => __( 'Apply Rate Limit to', 'simple-sales-tax' ),
@@ -445,6 +453,7 @@ class SST_Settings {
 					'customer' => __( 'Customer / Visitor (per user or session)', 'simple-sales-tax' ),
 					'global'   => __( 'Global (shared across all users)', 'simple-sales-tax' ),
 				),
+				'disabled'    => $disable_data_import_settings,
 			),
 			'taxcloud_rate_limit_window'  => array(
 				'title'       => __( 'Time Window (Minutes)', 'simple-sales-tax' ),
@@ -458,6 +467,7 @@ class SST_Settings {
 				'custom_attributes' => array(
 					'min' => 1,
 				),
+				'disabled'    => $disable_data_import_settings,
 			),
 			'show_rate_limit_notice'      => array(
 				'title'       => __( 'Notify Customer When Limited', 'simple-sales-tax' ),
@@ -469,6 +479,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => false,
+				'disabled'    => $disable_data_import_settings,
 			),
 			'remove_all_data'             => array(
 				'title'       => __( 'Remove All Data', 'simple-sales-tax' ),

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -73,6 +73,19 @@ class SST_Settings {
 	}
 
 	/**
+	 * Check whether Data Import mode is active.
+	 *
+	 * @return bool
+	 */
+	protected static function is_data_mover_mode() {
+		if ( empty( self::$settings ) ) {
+			self::load_settings();
+		}
+
+		return ! empty( self::$settings['data_mover'] );
+	}
+
+	/**
 	 * Get a list of plugin options and their default values.
 	 *
 	 * @since 5.0
@@ -82,6 +95,18 @@ class SST_Settings {
 			self::is_using_cart_block() ||
 			self::is_using_checkout_block()
 		);
+		$disable_exemption_settings = self::is_data_mover_mode();
+		$exemption_description      = __(
+			'If you have tax exempt customers, be sure to enable tax exemptions and enter your company name.',
+			'simple-sales-tax'
+		);
+
+		if ( $disable_exemption_settings ) {
+			$exemption_description .= '<br><strong>' . __(
+				'Tax exemptions are not supported in Data Import mode. These settings are disabled until Integration Mode is switched back to Real Time.',
+				'simple-sales-tax'
+			) . '</strong>';
+		}
 
 		$fields = array(
 			'taxcloud_settings'           => array(
@@ -172,10 +197,7 @@ class SST_Settings {
 			'exemption_settings'          => array(
 				'title'       => __( 'Exemption Settings', 'simple-sales-tax' ),
 				'type'        => 'title',
-				'description' => __(
-					'If you have tax exempt customers, be sure to enable tax exemptions and enter your company name.',
-					'simple-sales-tax'
-				),
+				'description' => $exemption_description,
 			),
 			'show_exempt'                 => array(
 				'title'       => __( 'Enable Tax Exemptions?', 'simple-sales-tax' ),
@@ -187,6 +209,7 @@ class SST_Settings {
 				'default'     => 'false',
 				'description' => __( 'Set this to "Yes" if you have tax exempt customers.', 'simple-sales-tax' ),
 				'desc_tip'    => true,
+				'disabled'    => $disable_exemption_settings,
 			),
 			'company_name'                => array(
 				'title'       => __( 'Company Name', 'simple-sales-tax' ),
@@ -197,6 +220,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
+				'disabled'    => $disable_exemption_settings,
 			),
 			'exempt_roles'                => array(
 				'title'       => __( 'Exempt User Roles', 'simple-sales-tax' ),
@@ -209,6 +233,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
+				'disabled'    => $disable_exemption_settings,
 			),
 			'restrict_exempt'             => array(
 				'title'       => __( 'Restrict to Exempt Roles', 'simple-sales-tax' ),
@@ -223,6 +248,7 @@ class SST_Settings {
 					'yes' => __( 'Yes', 'simple-sales-tax' ),
 					'no'  => __( 'No', 'simple-sales-tax' ),
 				),
+				'disabled'    => $disable_exemption_settings,
 			),
 			'display_settings'            => array(
 				'title'       => __( 'Display Settings', 'simple-sales-tax' ),

--- a/includes/frontend/class-sst-checkout.php
+++ b/includes/frontend/class-sst-checkout.php
@@ -547,6 +547,10 @@ class SST_Checkout extends SST_Abstract_Cart {
 	 * @return ExemptionCertificateBase
 	 */
 	public function get_certificate() {
+		if ( 'data_mover' === sst_integration_mode() ) {
+			return null;
+		}
+
 		$certificate_id = $this->get_certificate_id();
 
 		if ( $certificate_id && 'none' !== $certificate_id ) {
@@ -583,6 +587,11 @@ class SST_Checkout extends SST_Abstract_Cart {
 	 */
 	public function init_certificate_id() {
 		if ( ! WC()->session ) {
+			return;
+		}
+
+		if ( 'data_mover' === sst_integration_mode() ) {
+			WC()->session->set( 'sst_certificate_id', '' );
 			return;
 		}
 
@@ -800,8 +809,13 @@ class SST_Checkout extends SST_Abstract_Cart {
 	 * @param WC_Order $wc_order Order object
 	 */
 	protected function process_checkout( $data, $wc_order ) {
-		$certificate_id = $data['certificate_id'] ?? '';
-		$order          = new SST_Order( $wc_order );
+		$order = new SST_Order( $wc_order );
+
+		if ( 'data_mover' === sst_integration_mode() ) {
+			$certificate_id = '';
+		} else {
+			$certificate_id = $data['certificate_id'] ?? '';
+		}
 
 		if ( 'new' === $certificate_id ) {
 			$this->create_exemption_certificate( $data, $order );
@@ -977,6 +991,10 @@ class SST_Checkout extends SST_Abstract_Cart {
 	 * @param WP_Error $errors Checkout errors.
 	 */
 	protected function validate_exemption_certificate( $data, $errors ) {
+		if ( 'data_mover' === sst_integration_mode() ) {
+			return;
+		}
+
 		$certificate_id = $data['certificate_id'] ?? '';
 		$certificate    = $data['certificate'] ?? [];
 

--- a/includes/sst-functions.php
+++ b/includes/sst-functions.php
@@ -545,10 +545,11 @@ function sst_is_user_tax_exempt() {
 function sst_should_show_tax_exemption_form() {
 	$restricted = 'yes' === SST_Settings::get( 'restrict_exempt' );
 	$enabled    = 'true' === SST_Settings::get( 'show_exempt' );
+	$realtime   = 'data_mover' !== sst_integration_mode();
 
 	return apply_filters(
 		'sst_show_tax_exemption_form',
-		$enabled && ( ! $restricted || sst_is_user_tax_exempt() )
+		$enabled && $realtime && ( ! $restricted || sst_is_user_tax_exempt() )
 	);
 }
 


### PR DESCRIPTION
https://taxcloud.atlassian.net/browse/DEV-8511

**Summary**

Hide and disable unsupported tax exemption and real-time lookup controls when TaxCloud is in Data Import mode.

**Changes**

- Hide checkout tax exemption UI in Data Import mode for both classic and block checkout.
- Prevent stale checkout/block requests from applying or creating exemption certificates while Data Import mode is active.
- Disable Exemption Settings fields in admin during Data Import mode:
  - Enable Tax Exemptions
  - Company Name
  - Exempt User Roles
  - Restrict to Exempt Roles
- Disable real-time lookup/rate-limit settings in admin during Data Import mode:
  - Force Tax Lookup
  - Enable TaxCloud Rate Limiting
  - Number of Requests
  - Apply Rate Limit to
  - Time Window
  - Notify Customer When Limited
- Add admin helper text explaining why exemption and rate-limit settings are disabled.
- Preserve disabled settings values on save so they are not wiped by browser form submission.
