### PR TITLE
feat: Add 'Both Processing + Completed' option to TaxCloud Order Capture Trigger

### DIFF
--- a/includes/class-sst-order-controller.php
+++ b/includes/class-sst-order-controller.php
@@ -58,7 +58,8 @@ class SST_Order_Controller {
 	 * @since 5.0
 	 */
 	public function capture_order( $_order_id, $order ) {
-		if ( 'completed' !== SST_Settings::get_capture_trigger() ) {
+		$trigger = SST_Settings::get_capture_trigger();
+		if ( 'completed' !== $trigger && 'both' !== $trigger ) {
 			return false;
 		}
 
@@ -76,7 +77,8 @@ class SST_Order_Controller {
 	 * @throws Exception If capture fails.
 	 */
 	public function capture_processing_order( $_order_id, $order ) {
-		if ( 'processing' !== SST_Settings::get_capture_trigger() ) {
+		$trigger = SST_Settings::get_capture_trigger();
+		if ( 'processing' !== $trigger && 'both' !== $trigger ) {
 			return false;
 		}
 

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -396,6 +396,7 @@ class SST_Settings {
 				'options'     => array(
 					'completed'        => __( 'Completed order', 'simple-sales-tax' ),
 					'processing'       => __( 'Processing order (paid)', 'simple-sales-tax' ),
+					'both'             => __( 'Both Processing + Completed', 'simple-sales-tax' ),
 				),
 			),
 			'tax_based_on'                => array(
@@ -587,7 +588,7 @@ class SST_Settings {
 	 * @return string One of completed or processing.
 	 */
 	public static function get_capture_trigger() {
-		$valid   = array( 'completed', 'processing' );
+		$valid   = array( 'completed', 'processing', 'both' );
 		$trigger = self::get_default_capture_trigger();
 
 		if ( in_array( $trigger, $valid, true ) ) {


### PR DESCRIPTION
# Description

## The Issue
Currently, WooCommerce orders can only be captured in TaxCloud based on a single trigger setting:
- **Case 1 (Selected: Processing order):** If an order goes from `on-hold` directly to `completed`, capture is not triggered.
- **Case 2 (Selected: Completed order):** If an order goes from `on-hold` to `processing`, capture is not triggered.

There was no unified option that allowed capturing on *either* transition (Processing or Completed), which created tracking gaps for merchants depending on their order status workflows.

## The Solution
We added a third option, **Both Processing + Completed**, to allow order captures to be triggered on both transitions:

1. **Settings Update:**
   - Modified `capture_trigger` select options in [includes/class-sst-settings.php](file:///Users/akshuvo/Local%20Sites/dev-taxcloud/app/public/wp-content/plugins/simple-sales-tax/includes/class-sst-settings.php) to include the `both` value with the label "Both Processing + Completed".
   - Registered `both` as a valid return value in `SST_Settings::get_capture_trigger()`.

2. **Hook Logic Update:**
   - Modified [includes/class-sst-order-controller.php](file:///Users/akshuvo/Local%20Sites/dev-taxcloud/app/public/wp-content/plugins/simple-sales-tax/includes/class-sst-order-controller.php)'s `capture_order()` (completed hook) and `capture_processing_order()` (processing hook) to verify and run when the trigger is set to `both`.
   - If `both` is selected and the order transitions `on-hold` -> `processing` -> `completed`, it captures on `processing` and safely ignores the recapture attempt on `completed` without prompting errors.
