### PR TITLE
[DEV-9165] - Exemption certificate multiple user identifiers support

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -145,5 +145,26 @@
 
     toggleIntegrationDependentSettings();
 
+    // Disable exemption-dependent settings when "Enable Tax Exemptions?" is set to "No".
+    var exemptionSettingSelectors = [
+      '#woocommerce_wootax_company_name',
+      '#woocommerce_wootax_exempt_roles',
+      '#woocommerce_wootax_restrict_exempt',
+    ];
+
+    function toggleExemptionSettings() {
+      var exemptionDisabled = jQuery('#woocommerce_wootax_show_exempt').val() === 'false';
+
+      jQuery.each(exemptionSettingSelectors, function (index, selector) {
+        var $el = jQuery(selector);
+        $el.prop('disabled', exemptionDisabled);
+      });
+    }
+
+    jQuery('#woocommerce_wootax_show_exempt')
+      .on('change', toggleExemptionSettings);
+
+    toggleExemptionSettings();
+
   });
 })(SST);

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -64,19 +64,36 @@ class SST_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Preserve settings while their fields are disabled in Data Import mode.
+	 * Preserve settings while their fields are disabled in Data Import mode or when exemptions are disabled.
 	 *
 	 * @param array $settings Sanitized settings.
 	 *
 	 * @return array
 	 */
 	public function preserve_data_import_disabled_settings( $settings ) {
+		$current_settings = get_option( 'woocommerce_wootax_settings', array() );
+
+		// Preserve exemption sub-settings if exemptions are disabled
+		$show_exempt = $settings['show_exempt'] ?? ( $current_settings['show_exempt'] ?? 'false' );
+		if ( 'false' === $show_exempt ) {
+			$exemption_sub_keys = array(
+				'company_name',
+				'exempt_roles',
+				'restrict_exempt',
+			);
+
+			foreach ( $exemption_sub_keys as $key ) {
+				if ( array_key_exists( $key, $current_settings ) ) {
+					$settings[ $key ] = $current_settings[ $key ];
+				}
+			}
+		}
+
 		if ( empty( $settings['data_mover'] ) ) {
 			return $settings;
 		}
 
-		$current_settings = get_option( 'woocommerce_wootax_settings', array() );
-		$disabled_keys    = array(
+		$disabled_keys = array(
 			'show_exempt',
 			'company_name',
 			'exempt_roles',

--- a/includes/class-sst-blocks-integration.php
+++ b/includes/class-sst-blocks-integration.php
@@ -82,6 +82,13 @@ class SST_Blocks_Integration implements IntegrationInterface {
 			? WC()->session->get( 'sst_certificate_id', '' )
 			: '';
 
+		if ( empty( $selected ) && sst_is_user_tax_exempt() && ! empty( $certificates ) && ! ( WC()->session && WC()->session->get( 'sst_cert_explicitly_cleared' ) ) ) {
+			$selected = current( array_keys( $certificates ) );
+			if ( WC()->session ) {
+				WC()->session->set( 'sst_certificate_id', $selected );
+			}
+		}
+
 		return array(
 			'showExemptionForm'    => sst_should_show_tax_exemption_form(),
 			'certificateOptions'   => $options,

--- a/includes/class-sst-certificates.php
+++ b/includes/class-sst-certificates.php
@@ -218,6 +218,7 @@ class SST_Certificates {
 				array_filter(
 					array(
 						(string) $user->ID,
+						'customer-' . $user->ID,
 						$user->user_login,
 						$user->user_email,
 						$user->user_login . '-' . $user->ID,
@@ -306,8 +307,9 @@ class SST_Certificates {
 		$exempt_states = array();
 		if ( isset( $v3_cert['states'] ) && is_array( $v3_cert['states'] ) ) {
 			foreach ( $v3_cert['states'] as $state ) {
-				$abbr = $state['abbreviation'] ?? '';
-				if ( ! defined( '\TaxCloud\State::' . $abbr ) ) {
+				$abbr       = $state['abbreviation'] ?? '';
+				$const_name = ( 'OR' === $abbr ) ? '_OR' : $abbr;
+				if ( ! defined( '\TaxCloud\State::' . $const_name ) ) {
 					continue; // Skip invalid states
 				}
 

--- a/includes/class-sst-certificates.php
+++ b/includes/class-sst-certificates.php
@@ -209,18 +209,27 @@ class SST_Certificates {
 			$user = new \WP_User( $user_id );
 		}
 
-		if ( ! isset( $user->ID ) ) {
+		if ( ! isset( $user->ID ) || ! $user->ID ) {
 			return array(); /* Invalid user ID. */
 		}
 
+		$lookup_ids = array_values(
+			array_unique(
+				array_filter(
+					array(
+						(string) $user->ID,
+						$user->user_login,
+						$user->user_email,
+						$user->user_login . '-' . $user->ID,
+					)
+				)
+			)
+		);
+
 		try {
 			if ( sst_get_api_version() === 'v3' ) {
-			
 				$v3_exemptions = new \TaxCloud_V3\Exemptions();
 				$final_certs   = array();
-
-				// Try fetching by ID and Username to catch legacy certificates
-				$lookup_ids = array( (string) $user->ID, $user->user_login );
 
 				foreach ( $lookup_ids as $lookup_id ) {
 					$response = $v3_exemptions->get_certificates( array(
@@ -240,22 +249,26 @@ class SST_Certificates {
 				return $final_certs;
 			}
 
-	
-
-			$request = new \TaxCloud\Request\GetExemptCertificates(
-				SST_Settings::get( 'tc_id' ),
-				SST_Settings::get( 'tc_key' ),
-				$user->ID
-			);
-
-			$certificates = TaxCloud()->GetExemptCertificates( $request );
-
 			$final_certs = array();
 
-			foreach ( $certificates as $certificate ) {
-				$detail = $certificate->getDetail();
-				if ( ! $detail->getSinglePurchase() ) { /* Skip single certs */
-					$final_certs[ $certificate->getCertificateID() ] = $certificate;
+			foreach ( $lookup_ids as $lookup_id ) {
+				try {
+					$request = new \TaxCloud\Request\GetExemptCertificates(
+						SST_Settings::get( 'tc_id' ),
+						SST_Settings::get( 'tc_key' ),
+						$lookup_id
+					);
+
+					$certificates = TaxCloud()->GetExemptCertificates( $request );
+
+					foreach ( $certificates as $certificate ) {
+						$detail = $certificate->getDetail();
+						if ( ! $detail->getSinglePurchase() ) { /* Skip single certs */
+							$final_certs[ $certificate->getCertificateID() ] = $certificate;
+						}
+					}
+				} catch ( \Exception $ex ) {
+					// Ignore exception for individual lookup ID in v1 API.
 				}
 			}
 

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -215,7 +215,7 @@ class SST_Settings {
 					'false' => __( 'No', 'simple-sales-tax' ),
 				),
 				'default'     => 'false',
-				'description' => __( 'Set this to "Yes" if you have tax exempt customers.', 'simple-sales-tax' ),
+				'description' => __( 'Set this to "Yes" to allow customers to apply or create exemption certificates during checkout.', 'simple-sales-tax' ),
 				'desc_tip'    => true,
 				'disabled'    => $disable_data_import_settings,
 			),
@@ -237,10 +237,10 @@ class SST_Settings {
 				'options'     => self::get_user_roles(),
 				'default'     => array( 'exempt-customer' ),
 				'description' => __(
-					'When a user with one of these roles shops on your site, WooTax will automatically find and apply the first exemption certificate associated with their account. Convenient if you have repeat exempt customers.',
+					'When a user with one of these roles shops on your site, TaxCloud will automatically find and apply the first exemption certificate associated with their account. Convenient if you have repeat exempt customers.',
 					'simple-sales-tax'
 				),
-				'desc_tip'    => true,
+				'desc_tip'    => false,
 				'disabled'    => $disable_data_import_settings,
 			),
 			'restrict_exempt'             => array(
@@ -248,7 +248,7 @@ class SST_Settings {
 				'type'        => 'select',
 				'default'     => 'no',
 				'description' => __(
-					'Set this to "Yes" to restrict users aside from those specified above from seeing the exemption form during checkout.',
+					'Set this to "Yes" so only customers assigned to an Exempt User Role can view and use the tax exemption form during checkout.',
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -116,6 +116,11 @@ class SST_Settings {
 			) . '</strong>';
 		}
 
+		$disable_exemption_sub_settings = (
+			$disable_data_import_settings ||
+			'false' === self::get( 'show_exempt', 'false' )
+		);
+
 		$fields = array(
 			'taxcloud_settings'           => array(
 				'title'       => __( 'TaxCloud Settings', 'simple-sales-tax' ),
@@ -228,7 +233,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => true,
-				'disabled'    => $disable_data_import_settings,
+				'disabled'    => $disable_exemption_sub_settings,
 			),
 			'exempt_roles'                => array(
 				'title'       => __( 'Exempt User Roles', 'simple-sales-tax' ),
@@ -241,7 +246,7 @@ class SST_Settings {
 					'simple-sales-tax'
 				),
 				'desc_tip'    => false,
-				'disabled'    => $disable_data_import_settings,
+				'disabled'    => $disable_exemption_sub_settings,
 			),
 			'restrict_exempt'             => array(
 				'title'       => __( 'Restrict to Exempt Roles', 'simple-sales-tax' ),
@@ -256,7 +261,7 @@ class SST_Settings {
 					'yes' => __( 'Yes', 'simple-sales-tax' ),
 					'no'  => __( 'No', 'simple-sales-tax' ),
 				),
-				'disabled'    => $disable_data_import_settings,
+				'disabled'    => $disable_exemption_sub_settings,
 			),
 			'display_settings'            => array(
 				'title'       => __( 'Display Settings', 'simple-sales-tax' ),

--- a/includes/frontend/class-sst-checkout.php
+++ b/includes/frontend/class-sst-checkout.php
@@ -604,17 +604,25 @@ class SST_Checkout extends SST_Abstract_Cart {
 
 			if ( 'none' === $certificate_id ) {
 				$certificate_id = '';
+				WC()->session->set( 'sst_cert_explicitly_cleared', true );
+			} else {
+				WC()->session->set( 'sst_cert_explicitly_cleared', false );
 			}
 
 			if ( $certificate_id !== WC()->session->get( 'sst_certificate_id' ) ) {
 				WC()->session->set( 'sst_certificate_id', $certificate_id );
 				WC()->session->set( 'sst_packages', array() ); // Clear cache on selection change
 			}
-		} else if ( is_null( WC()->session->sst_certificate_id ) ) {
-			WC()->session->set(
-				'sst_certificate_id',
-				$this->get_default_certificate_id()
-			);
+		} else {
+			$current_cert_id = WC()->session->get( 'sst_certificate_id' );
+			$is_cleared      = (bool) WC()->session->get( 'sst_cert_explicitly_cleared', false );
+
+			if ( ( is_null( $current_cert_id ) || '' === $current_cert_id ) && ! $is_cleared ) {
+				$default_id = $this->get_default_certificate_id();
+				if ( ! empty( $default_id ) ) {
+					WC()->session->set( 'sst_certificate_id', $default_id );
+				}
+			}
 		}
 
 		// Ensure SST packages are initialized in session


### PR DESCRIPTION
https://taxcloud.atlassian.net/browse/DEV-9165

- Expanded certificate fetching to query by User ID, `customer-{id}`, Username, Email, and `{username}-{id}`
- Fixed Oregon (`_OR`) state constant validation bug in certificate parser
- Fixed default certificate auto-selection at checkout for exempt user roles (classic & block checkout)
- Updated Exemption Settings copy and replaced legacy "WooTax" references with "TaxCloud"
- Rendered Exempt User Roles description directly on page instead of inside tooltip
- Dynamically disabled sub-exemption setting fields when "Enable Tax Exemptions?" is set to "No"
- Preserved saved values of disabled sub-exemption settings when saving options