### PR TITLE
[DEV-9123] - Exempt admin calculations from rate limiting and surface customer notices

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -129,6 +129,7 @@
       '#woocommerce_wootax_taxcloud_rate_limit_requests',
       '#woocommerce_wootax_taxcloud_rate_limit_scope',
       '#woocommerce_wootax_taxcloud_rate_limit_window',
+      '#woocommerce_wootax_taxcloud_rate_limit_skip_admin',
       '#woocommerce_wootax_show_rate_limit_notice',
     ];
 

--- a/assets/js/blocks/rate-limit-notice.js
+++ b/assets/js/blocks/rate-limit-notice.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { dispatch, select, subscribe } from '@wordpress/data';
+
+const EXTENSION_NAMESPACE = 'simple-sales-tax';
+const NOTICE_ID = 'simple-sales-tax-rate-limit';
+
+let previousMessage = '';
+let previousContext = '';
+
+/**
+ * Display or remove the TaxCloud rate-limit notice based on Store API data.
+ */
+const syncRateLimitNotice = () => {
+	const cart = select( CART_STORE_KEY ).getCartData();
+	const message =
+		cart?.extensions?.[ EXTENSION_NAMESPACE ]?.rate_limit_notice || '';
+	const context = document.body.classList.contains( 'woocommerce-checkout' )
+		? 'wc/checkout'
+		: 'wc/cart';
+
+	if ( message === previousMessage && context === previousContext ) {
+		return;
+	}
+
+	if ( previousMessage ) {
+		dispatch( 'core/notices' ).removeNotice( NOTICE_ID, previousContext );
+	}
+
+	if ( message ) {
+		dispatch( 'core/notices' ).createNotice( 'info', message, {
+			id: NOTICE_ID,
+			context,
+			isDismissible: true,
+		} );
+	}
+
+	previousMessage = message;
+	previousContext = context;
+};
+
+syncRateLimitNotice();
+subscribe( syncRateLimitNotice, CART_STORE_KEY );

--- a/includes/admin/class-sst-integration.php
+++ b/includes/admin/class-sst-integration.php
@@ -103,6 +103,7 @@ class SST_Integration extends WC_Integration {
 			'taxcloud_rate_limit_requests',
 			'taxcloud_rate_limit_scope',
 			'taxcloud_rate_limit_window',
+			'taxcloud_rate_limit_skip_admin',
 			'show_rate_limit_notice',
 		);
 

--- a/includes/class-sst-blocks-integration.php
+++ b/includes/class-sst-blocks-integration.php
@@ -12,6 +12,22 @@ use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 class SST_Blocks_Integration implements IntegrationInterface {
 
 	/**
+	 * Block context for this integration.
+	 *
+	 * @var string
+	 */
+	protected $block_context;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $block_context Block context: cart or checkout.
+	 */
+	public function __construct( $block_context = 'checkout' ) {
+		$this->block_context = $block_context;
+	}
+
+	/**
 	 * The name of the integration.
 	 *
 	 * @return string
@@ -24,6 +40,12 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * When called invokes any initialization/setup for the integration.
 	 */
 	public function initialize() {
+		$this->register_rate_limit_notice_script();
+
+		if ( 'checkout' !== $this->block_context ) {
+			return;
+		}
+
 		$this->register_frontend_scripts();
 		$this->register_editor_scripts();
 		$this->register_block_styles();
@@ -41,7 +63,13 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * @return string[]
 	 */
 	public function get_script_handles() {
-		return array( 'sst-tax-exemption-block-frontend' );
+		$handles = array( 'sst-rate-limit-notice' );
+
+		if ( 'checkout' === $this->block_context ) {
+			$handles[] = 'sst-tax-exemption-block-frontend';
+		}
+
+		return $handles;
 	}
 
 	/**
@@ -50,6 +78,10 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * @return string[]
 	 */
 	public function get_editor_script_handles() {
+		if ( 'checkout' !== $this->block_context ) {
+			return array();
+		}
+
 		return array( 'sst-tax-exemption-block-editor' );
 	}
 
@@ -59,6 +91,10 @@ class SST_Blocks_Integration implements IntegrationInterface {
 	 * @return array
 	 */
 	public function get_script_data() {
+		if ( 'checkout' !== $this->block_context ) {
+			return array();
+		}
+
 		if ( ! sst_should_show_tax_exemption_form() ) {
 			return array(
 				'showExemptionForm'    => false,
@@ -95,6 +131,28 @@ class SST_Blocks_Integration implements IntegrationInterface {
 			'selectedCertificate'  => $selected,
 			'isUserLoggedIn'       => is_user_logged_in(),
 			'myAccountEndpointUrl' => wc_get_account_endpoint_url( 'exemption-certificates' ),
+		);
+	}
+
+	/**
+	 * Register the rate-limit notice frontend script.
+	 */
+	public function register_rate_limit_notice_script() {
+		$script_url        = SST()->url( 'build/rate-limit-notice.js' );
+		$script_asset_path = SST()->path( 'build/rate-limit-notice.asset.php' );
+		$script_asset      = file_exists( $script_asset_path )
+			? require $script_asset_path
+			: array(
+				'dependencies' => array(),
+				'version'      => $this->get_file_version( $script_asset_path ),
+			);
+
+		wp_register_script(
+			'sst-rate-limit-notice',
+			$script_url,
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
 		);
 	}
 

--- a/includes/class-sst-blocks.php
+++ b/includes/class-sst-blocks.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use \Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema;
 use \Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
 
 /**
@@ -55,7 +56,7 @@ class SST_Blocks {
 		);
 		add_action(
 			'woocommerce_blocks_loaded',
-			array( $this, 'register_checkout_endpoint_data' )
+			array( $this, 'register_endpoint_data' )
 		);
 	}
 
@@ -66,9 +67,16 @@ class SST_Blocks {
 		require_once __DIR__ . '/class-sst-blocks-integration.php';
 
 		add_action(
+			'woocommerce_blocks_cart_block_registration',
+			function( $integration_registry ) {
+				$integration_registry->register( new SST_Blocks_Integration( 'cart' ) );
+			}
+		);
+
+		add_action(
 			'woocommerce_blocks_checkout_block_registration',
 			function( $integration_registry ) {
-				$integration_registry->register( new SST_Blocks_Integration() );
+				$integration_registry->register( new SST_Blocks_Integration( 'checkout' ) );
 			}
 		);
 	}
@@ -151,15 +159,60 @@ class SST_Blocks {
 	}
 
 	/**
-	 * Register custom extension data for checkout endpoint.
+	 * Get schema for cart endpoint extension data.
+	 *
+	 * @return array
 	 */
-	public function register_checkout_endpoint_data() {
+	public function get_cart_schema() {
+		return array(
+			'rate_limit_notice' => array(
+				'type'     => 'string',
+				'readonly' => true,
+			),
+		);
+	}
+
+	/**
+	 * Get custom extension data for the cart endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_cart_data() {
+		$message = '';
+
+		if ( 'yes' === SST_Settings::get( 'show_rate_limit_notice', 'no' ) ) {
+			$rate_limit = new SST_Rate_Limit();
+
+			if ( $rate_limit->limit_reached() ) {
+				$message = SST_Rate_Limit::get_notice_message();
+			}
+		}
+
+		return array(
+			'rate_limit_notice' => $message,
+		);
+	}
+
+	/**
+	 * Register custom extension data for Store API endpoints.
+	 */
+	public function register_endpoint_data() {
 		woocommerce_store_api_register_endpoint_data(
 			array(
 				'endpoint'        => CheckoutSchema::IDENTIFIER,
 				'namespace'       => 'simple-sales-tax',
 				'data_callback'   => null,
 				'schema_callback' => array( $this, 'get_checkout_schema' ),
+				'schema_type'     => ARRAY_A,
+			)
+		);
+
+		woocommerce_store_api_register_endpoint_data(
+			array(
+				'endpoint'        => CartSchema::IDENTIFIER,
+				'namespace'       => 'simple-sales-tax',
+				'data_callback'   => array( $this, 'get_cart_data' ),
+				'schema_callback' => array( $this, 'get_cart_schema' ),
 				'schema_type'     => ARRAY_A,
 			)
 		);

--- a/includes/class-sst-rate-limit.php
+++ b/includes/class-sst-rate-limit.php
@@ -23,6 +23,15 @@ class SST_Rate_Limit {
 	private $identifier;
 
 	/**
+	 * Get the customer-facing message shown when tax lookup is skipped.
+	 *
+	 * @return string
+	 */
+	public static function get_notice_message() {
+		return __( 'Tax calculation is temporarily unavailable. Your order will continue without live tax estimation.', 'simple-sales-tax' );
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $identifier Identifier for the request (optional).

--- a/includes/class-sst-rate-limit.php
+++ b/includes/class-sst-rate-limit.php
@@ -59,6 +59,27 @@ class SST_Rate_Limit {
 	}
 
 	/**
+	 * Check if the current request is exempt from rate limiting.
+	 *
+	 * @return bool
+	 */
+	public function is_exempt() {
+		// Background jobs (cron) should always bypass the limit.
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			return true;
+		}
+
+		// Admin user exemption check.
+		if ( 'yes' === SST_Settings::get( 'taxcloud_rate_limit_skip_admin', 'yes' ) ) {
+			if ( is_admin() || current_user_can( 'manage_woocommerce' ) || current_user_can( 'manage_options' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if the rate limit has been reached.
 	 *
 	 * @return bool
@@ -69,8 +90,7 @@ class SST_Rate_Limit {
 			return false;
 		}
 
-		// Admin or background jobs (cron) should bypass the limit.
-		if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) ) {
+		if ( $this->is_exempt() ) {
 			return false;
 		}
 
@@ -95,6 +115,10 @@ class SST_Rate_Limit {
 	public function increment_count() {
 		// Rate limiting disabled?
 		if ( 'yes' !== SST_Settings::get( 'enable_taxcloud_rate_limit', 'no' ) ) {
+			return;
+		}
+
+		if ( $this->is_exempt() ) {
 			return;
 		}
 

--- a/includes/class-sst-settings.php
+++ b/includes/class-sst-settings.php
@@ -478,6 +478,18 @@ class SST_Settings {
 				),
 				'disabled'    => $disable_data_import_settings,
 			),
+			'taxcloud_rate_limit_skip_admin' => array(
+				'title'       => __( 'Skip Admin Order Rate Limiting', 'simple-sales-tax' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Exempt admin users and backend order calculations from rate limits', 'simple-sales-tax' ),
+				'default'     => 'yes',
+				'description' => __(
+					'When enabled, TaxCloud rate limits will not apply to orders created or calculated by admin users.',
+					'simple-sales-tax'
+				),
+				'desc_tip'    => false,
+				'disabled'    => $disable_data_import_settings,
+			),
 			'show_rate_limit_notice'      => array(
 				'title'       => __( 'Notify Customer When Limited', 'simple-sales-tax' ),
 				'type'        => 'checkbox',

--- a/includes/frontend/class-sst-checkout.php
+++ b/includes/frontend/class-sst-checkout.php
@@ -7,7 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use \TaxCloud\ExemptionCertificate;
 use \TaxCloud\ExemptionCertificateBase;
-use Automattic\WooCommerce\StoreApi\Utilities\NoticeHandler;
 
 /**
  * Checkout.
@@ -59,14 +58,6 @@ class SST_Checkout extends SST_Abstract_Cart {
 		}
 
 		add_action( 'woocommerce_checkout_create_order_shipping_item', array( $this, 'add_shipping_meta' ), 10, 3 );
-
-		add_action( 'woocommerce_store_api_cart_get_cart', function () {
-		    NoticeHandler::add_notice(
-		        'delivery_info_notice',
-		        'Delivery may take 2–3 extra days for remote areas.',
-		        'notice' // notice | success | error
-		    );
-		});
 
 		parent::__construct();
 
@@ -664,7 +655,7 @@ class SST_Checkout extends SST_Abstract_Cart {
 		$rate_limit = new SST_Rate_Limit();
 
 		if ( $rate_limit->limit_reached() ) {
-			$message = __( 'Tax calculation is temporarily unavailable. Your order will continue without live tax estimation.', 'simple-sales-tax' );
+			$message = SST_Rate_Limit::get_notice_message();
 
 			if ( ! wc_has_notice( $message, 'notice' ) ) {
 				wc_add_notice( $message, 'notice' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,10 @@ const defaultRules = defaultConfig.module.rules.filter((rule) => {
 module.exports = {
 	...defaultConfig,
 	entry: {
+		'rate-limit-notice': path.resolve(
+			process.cwd(),
+			'assets/js/blocks/rate-limit-notice.js',
+		),
 		'tax-exemption-block': path.resolve(
 			process.cwd(),
 			'assets/js/blocks/tax-exemption/index.js',


### PR DESCRIPTION
## Summary
https://taxcloud.atlassian.net/browse/DEV-9123

- Add an admin/backend exemption setting for TaxCloud rate limits.
- Bypass rate-limit checks and tracking for cron jobs and eligible admin users.
- Expose rate-limit notices through the WooCommerce Cart and Checkout Store API blocks.
- Add a frontend notice script for cart and checkout contexts.
- Centralize the customer-facing rate-limit message.

