### PR TITLE
Fixed #424: TypeError: key(): Argument #1 ($array) must be of type array, null given in do_package_lookup crashes WooCommerce Subscription renewals on PHP 8.2

### DIFF
--- a/includes/abstracts/class-sst-abstract-cart.php
+++ b/includes/abstracts/class-sst-abstract-cart.php
@@ -237,12 +237,19 @@ abstract class SST_Abstract_Cart {
 
 		try {
 			$package['response'] = TaxCloud()->Lookup( $package['request'] );
+
+			if ( ! is_array( $package['response'] ) || empty( $package['response'] ) ) {
+				throw new UnexpectedValueException(
+					__( 'TaxCloud returned an invalid lookup response.', 'simple-sales-tax' )
+				);
+			}
+
 			$package['cart_id']  = key( $package['response'] );
 
 			$rate_limit->increment_count();
 
 			SST_Logger::debug( __( 'Tax lookup response:', 'simple-sales-tax' ), $package );
-		} catch ( Exception $ex ) {
+		} catch ( Throwable $ex ) {
 			$package['response'] = new WP_Error( 'lookup_error', $ex->getMessage() );
 			// Logging.
 			SST_Logger::debug( __( 'Tax lookup failed. Exception:', 'simple-sales-tax' ), $ex );

--- a/includes/integrations/class-sst-subscriptions.php
+++ b/includes/integrations/class-sst-subscriptions.php
@@ -82,7 +82,7 @@ class SST_Subscriptions {
 		try {
 			$order->calculate_taxes();
 			$order->calculate_totals( false );
-		} catch ( Exception $ex ) {
+		} catch ( Throwable $ex ) {
 			$order->add_order_note(
 				sprintf(
 					/* translators: 1 - Renewal order ID, 2 - Error message */
@@ -91,6 +91,9 @@ class SST_Subscriptions {
 					$ex->getMessage()
 				)
 			);
+
+			// Logging.
+			SST_Logger::order_log( __( 'Failed to calculate sales tax for renewal order.', 'simple-sales-tax' ), $order->get_id(), $ex->getMessage() );
 		}
 
 		return $renewal_order;


### PR DESCRIPTION
Validate TaxCloud lookup responses and catch Throwable exceptions to improve error handling and logging

https://github.com/FedTax/simplesalestax/issues/424